### PR TITLE
fix/talent

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -3,8 +3,6 @@ name: Dependency Submission (Gradle)
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   schedule:
     - cron: '0 23 * * *'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@
      ```bash
       ./gradlew build
       ./gradlew bootRun
-      java -jar build/libs/bigtablet-homepage-server-1.5.7.jar
+      java -jar build/libs/bigtablet-homepage-server-1.5.8.jar
      ```
    - If you're on Window
      ```bash
       gradlew build
       gradlew bootRun
-      java -jar build/libs/bigtablet-homepage-server-1.5.7.jar
+      java -jar build/libs/bigtablet-homepage-server-1.5.8.jar
      ```
 4. If a port conflict occurs on port 8080, change the port number at the end of the command below to one that is not in use, and then run it.
    ```bash
-   java -jar build/libs/bigtablet-homepage-server-1.5.7.jar --server.port=[port number]
+   java -jar build/libs/bigtablet-homepage-server-1.5.8.jar --server.port=[port number]
    ```
   

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@
      ```bash
       ./gradlew build
       ./gradlew bootRun
-      java -jar build/libs/bigtablet-homepage-server-1.5.10.jar
+      java -jar build/libs/bigtablet-homepage-server-1.5.11.jar
      ```
    - If you're on Window
      ```bash
       gradlew build
       gradlew bootRun
-      java -jar build/libs/bigtablet-homepage-server-1.5.10.jar
+      java -jar build/libs/bigtablet-homepage-server-1.5.11.jar
      ```
 4. If a port conflict occurs on port 8080, change the port number at the end of the command below to one that is not in use, and then run it.
    ```bash
-   java -jar build/libs/bigtablet-homepage-server-1.5.10.jar --server.port=[port number]
+   java -jar build/libs/bigtablet-homepage-server-1.5.11.jar --server.port=[port number]
    ```
   

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bigtablet Homepage Server
 ### This project was developed using the following technologies.
-- **Spring Boot** (4.0.0)
+- **Spring Boot** (4.0.4)
 - **Java** (21)
 - **MySQL** (8.0)
 ---
@@ -15,16 +15,16 @@
      ```bash
       ./gradlew build
       ./gradlew bootRun
-      java -jar build/libs/bigtablet-homepage-server-1.5.8.jar
+      java -jar build/libs/bigtablet-homepage-server-1.5.10.jar
      ```
    - If you're on Window
      ```bash
       gradlew build
       gradlew bootRun
-      java -jar build/libs/bigtablet-homepage-server-1.5.8.jar
+      java -jar build/libs/bigtablet-homepage-server-1.5.10.jar
      ```
 4. If a port conflict occurs on port 8080, change the port number at the end of the command below to one that is not in use, and then run it.
    ```bash
-   java -jar build/libs/bigtablet-homepage-server-1.5.8.jar --server.port=[port number]
+   java -jar build/libs/bigtablet-homepage-server-1.5.10.jar --server.port=[port number]
    ```
   

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.bigtablet'
-version = '1.5.7'
+version = '1.5.8'
 description = 'bigtablet-homepage-server'
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.bigtablet'
-version = '1.5.10'
+version = '1.5.11'
 description = 'bigtablet-homepage-server'
 
 java {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/query/NewsQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/query/NewsQueryService.java
@@ -24,7 +24,7 @@ public class NewsQueryService {
      */
     public News find(Long idx) {
         NewsEntity entity = newsJpaRepository
-                .findByIdx(idx)
+                .findById(idx)
                 .orElseThrow(() -> NewsNotFoundException.EXCEPTION);
         return News.of(entity);
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/service/NewsService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/service/NewsService.java
@@ -69,7 +69,7 @@ public class NewsService {
      */
     private NewsEntity getNewsEntity(Long idx) {
         return newsJpaRepository
-                .findByIdx(idx)
+                .findById(idx)
                 .orElseThrow(() -> NewsNotFoundException.EXCEPTION);
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/domain/repository/jpa/NewsJpaRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/domain/repository/jpa/NewsJpaRepository.java
@@ -3,10 +3,6 @@ package com.bigtablet.bigtablethompageserver.domain.news.domain.repository.jpa;
 import com.bigtablet.bigtablethompageserver.domain.news.domain.entity.NewsEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface NewsJpaRepository extends JpaRepository<NewsEntity, Long> {
-
-    Optional<NewsEntity> findByIdx(Long idx);
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/query/TalentQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/query/TalentQueryService.java
@@ -24,7 +24,7 @@ public class TalentQueryService {
      */
     public Talent find(Long idx) {
         return talentJpaRepository
-                .findByIdx(idx)
+                .findById(idx)
                 .map(Talent::of)
                 .orElseThrow(() -> TalentNotFoundException.EXCEPTION);
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
@@ -55,7 +55,7 @@ public class TalentService {
     public void editActive(Long idx, boolean isActive) {
         log.info("[TalentService] editActive - idx={}, isActive={}", idx, isActive);
         TalentEntity entity = talentJpaRepository
-                .findByIdx(idx)
+                .findById(idx)
                 .orElseThrow(() -> TalentNotFoundException.EXCEPTION);
         if (isActive) {
             entity.activate();

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/repository/jpa/TalentJpaRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/repository/jpa/TalentJpaRepository.java
@@ -3,12 +3,8 @@ package com.bigtablet.bigtablethompageserver.domain.talent.domain.repository.jpa
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.entity.TalentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface TalentJpaRepository extends JpaRepository<TalentEntity, Long> {
 
     boolean existsByEmail(String email);
-
-    Optional<TalentEntity> findByIdx(Long idx);
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/repository/jpa/TalentJpaRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/repository/jpa/TalentJpaRepository.java
@@ -1,11 +1,7 @@
 package com.bigtablet.bigtablethompageserver.domain.talent.domain.repository.jpa;
 
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.entity.TalentEntity;
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -13,8 +9,6 @@ public interface TalentJpaRepository extends JpaRepository<TalentEntity, Long> {
 
     boolean existsByEmail(String email);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select t from TalentEntity t where t.idx = :idx")
-    Optional<TalentEntity> findByIdx(@Param("idx") Long idx);
+    Optional<TalentEntity> findByIdx(Long idx);
 
 }


### PR DESCRIPTION
## 제목
fix/talent - 인재 조회 API 트랜잭션 에러 수정

## 작업한 내용
- TalentJpaRepository.findByIdx()에서 불필요한 @Lock(PESSIMISTIC_WRITE) 제거
- 단순 조회/활성화 토글에 비관적 락이 불필요하여 제거
- GET /talent?idx= API의 "No active transaction" 에러 해결

## 전달할 추가 이슈
- 없음