### PR TITLE
fix/auth-service-dto-boundary

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/response/JsonWebTokenResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/response/JsonWebTokenResponse.java
@@ -2,9 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.auth.application.response;
 
 import com.bigtablet.bigtablethompageserver.domain.auth.domain.model.AuthToken;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Builder;
 
-@Builder
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record JsonWebTokenResponse (
 
@@ -13,9 +11,9 @@ public record JsonWebTokenResponse (
 
 ){
     public static JsonWebTokenResponse of(AuthToken authToken) {
-        return JsonWebTokenResponse.builder()
-                .accessToken(authToken.accessToken())
-                .refreshToken(authToken.refreshToken())
-                .build();
+        return new JsonWebTokenResponse(
+                authToken.accessToken(),
+                authToken.refreshToken()
+        );
     }
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/response/JsonWebTokenResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/response/JsonWebTokenResponse.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.domain.auth.application.response;
 
+import com.bigtablet.bigtablethompageserver.domain.auth.domain.model.AuthToken;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
@@ -10,4 +11,11 @@ public record JsonWebTokenResponse (
     String accessToken,
     String refreshToken
 
-){}
+){
+    public static JsonWebTokenResponse of(AuthToken authToken) {
+        return JsonWebTokenResponse.builder()
+                .accessToken(authToken.accessToken())
+                .refreshToken(authToken.refreshToken())
+                .build();
+    }
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/response/RefreshTokenResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/response/RefreshTokenResponse.java
@@ -2,9 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.auth.application.response;
 
 import com.bigtablet.bigtablethompageserver.domain.auth.domain.model.AccessToken;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Builder;
 
-@Builder
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record RefreshTokenResponse (
 
@@ -12,8 +10,6 @@ public record RefreshTokenResponse (
 
 ){
     public static RefreshTokenResponse of(AccessToken accessToken) {
-        return RefreshTokenResponse.builder()
-                .accessToken(accessToken.accessToken())
-                .build();
+        return new RefreshTokenResponse(accessToken.accessToken());
     }
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/response/RefreshTokenResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/response/RefreshTokenResponse.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.domain.auth.application.response;
 
+import com.bigtablet.bigtablethompageserver.domain.auth.domain.model.AccessToken;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
@@ -9,4 +10,10 @@ public record RefreshTokenResponse (
 
     String accessToken
 
-){}
+){
+    public static RefreshTokenResponse of(AccessToken accessToken) {
+        return RefreshTokenResponse.builder()
+                .accessToken(accessToken.accessToken())
+                .build();
+    }
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/service/AuthService.java
@@ -34,10 +34,10 @@ public class AuthService {
      */
     public AuthToken generateToken(String email) {
         log.info("[AuthService] generateToken - email={}", email);
-        return AuthToken.builder()
-                .accessToken(jwtProvider.generateAccessToken(email))
-                .refreshToken(jwtProvider.generateRefreshToken(email))
-                .build();
+        return new AuthToken(
+                jwtProvider.generateAccessToken(email),
+                jwtProvider.generateRefreshToken(email)
+        );
     }
 
     /**
@@ -48,9 +48,7 @@ public class AuthService {
     public AccessToken refreshToken(String refreshToken) {
         log.info("[AuthService] refreshToken");
         Jws<Claims> claims = jwtProvider.getClaims(refreshToken);
-        return AccessToken.builder()
-                .accessToken(jwtProvider.generateAccessToken(claims.getBody().getSubject()))
-                .build();
+        return new AccessToken(jwtProvider.generateAccessToken(claims.getBody().getSubject()));
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.bigtablet.bigtablethompageserver.domain.auth.application.service;
 
-import com.bigtablet.bigtablethompageserver.domain.auth.application.response.JsonWebTokenResponse;
-import com.bigtablet.bigtablethompageserver.domain.auth.application.response.RefreshTokenResponse;
+import com.bigtablet.bigtablethompageserver.domain.auth.domain.model.AccessToken;
+import com.bigtablet.bigtablethompageserver.domain.auth.domain.model.AuthToken;
 import com.bigtablet.bigtablethompageserver.domain.user.exception.PasswordWrongException;
 import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
 import com.bigtablet.bigtablethompageserver.global.infra.email.exception.EmailCodeValidException;
@@ -30,11 +30,11 @@ public class AuthService {
     /**
      * JWT 토큰 생성 (액세스 + 리프레시)
      * @param email String 사용자 이메일
-     * @return JsonWebTokenResponse 액세스 토큰과 리프레시 토큰
+     * @return AuthToken 액세스 토큰과 리프레시 토큰을 담은 도메인 객체
      */
-    public JsonWebTokenResponse generateToken(String email) {
+    public AuthToken generateToken(String email) {
         log.info("[AuthService] generateToken - email={}", email);
-        return JsonWebTokenResponse.builder()
+        return AuthToken.builder()
                 .accessToken(jwtProvider.generateAccessToken(email))
                 .refreshToken(jwtProvider.generateRefreshToken(email))
                 .build();
@@ -43,12 +43,12 @@ public class AuthService {
     /**
      * 리프레시 토큰으로 액세스 토큰 재발급
      * @param refreshToken String 리프레시 토큰
-     * @return RefreshTokenResponse 재발급된 액세스 토큰
+     * @return AccessToken 재발급된 액세스 토큰 도메인 객체
      */
-    public RefreshTokenResponse refreshToken(String refreshToken) {
+    public AccessToken refreshToken(String refreshToken) {
         log.info("[AuthService] refreshToken");
         Jws<Claims> claims = jwtProvider.getClaims(refreshToken);
-        return RefreshTokenResponse.builder()
+        return AccessToken.builder()
                 .accessToken(jwtProvider.generateAccessToken(claims.getBody().getSubject()))
                 .build();
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/usecase/AuthUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/usecase/AuthUseCase.java
@@ -52,7 +52,7 @@ public class AuthUseCase {
         log.info("[AuthUseCase] signIn - email={}", request.email());
         User user = userQueryService.find(request.email());
         authService.checkPassword(request.password(), user.password());
-        return authService.generateToken(request.email());
+        return JsonWebTokenResponse.of(authService.generateToken(request.email()));
     }
 
     /**
@@ -62,7 +62,7 @@ public class AuthUseCase {
      */
     public RefreshTokenResponse refresh(RefreshTokenRequest request) {
         log.info("[AuthUseCase] refresh");
-        return authService.refreshToken(request.refreshToken());
+        return RefreshTokenResponse.of(authService.refreshToken(request.refreshToken()));
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/domain/model/AccessToken.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/domain/model/AccessToken.java
@@ -1,8 +1,5 @@
 package com.bigtablet.bigtablethompageserver.domain.auth.domain.model;
 
-import lombok.Builder;
-
-@Builder
 public record AccessToken(
         String accessToken
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/domain/model/AccessToken.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/domain/model/AccessToken.java
@@ -1,0 +1,8 @@
+package com.bigtablet.bigtablethompageserver.domain.auth.domain.model;
+
+import lombok.Builder;
+
+@Builder
+public record AccessToken(
+        String accessToken
+) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/domain/model/AuthToken.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/domain/model/AuthToken.java
@@ -1,0 +1,9 @@
+package com.bigtablet.bigtablethompageserver.domain.auth.domain.model;
+
+import lombok.Builder;
+
+@Builder
+public record AuthToken(
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/domain/model/AuthToken.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/domain/model/AuthToken.java
@@ -1,8 +1,5 @@
 package com.bigtablet.bigtablethompageserver.domain.auth.domain.model;
 
-import lombok.Builder;
-
-@Builder
 public record AuthToken(
         String accessToken,
         String refreshToken


### PR DESCRIPTION
## 제목
fix/auth-service-dto-boundary — AuthService에서 Response DTO 반환 제거

Closes #83

## 작업한 내용
- `domain/auth/domain/model/`에 도메인 record 추가:
  - `AuthToken(accessToken, refreshToken)`
  - `AccessToken(accessToken)`
- `AuthService#generateToken` 반환 타입 `JsonWebTokenResponse` → `AuthToken`
- `AuthService#refreshToken` 반환 타입 `RefreshTokenResponse` → `AccessToken`
- Response DTO 변환을 `AuthUseCase`로 이동 (`.of(domain)` 정적 팩토리 사용)
  - `JsonWebTokenResponse.of(authToken)` / `RefreshTokenResponse.of(accessToken)`
- `AuthService`의 Response DTO import 제거

이로써 Service 레이어가 Domain 객체만 반환하는 컨벤션을 만족합니다.

## 전달할 추가 이슈
- #82와 동일 도메인을 건드리므로 머지 순서 의존성 있음 (#82 먼저 머지 후 본 PR rebase 필요)
- `AuthService#checkPassword`, `#checkAuthNum`은 query 스타일 메서드라 엄격한 CQS 해석상 `AuthQueryService`로 옮길 여지가 있으나, 본 PR scope에서는 다루지 않음