### PR TITLE
fix/long-param-services

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
@@ -1,18 +1,13 @@
 package com.bigtablet.bigtablethompageserver.domain.job.application.service;
 
 import com.bigtablet.bigtablethompageserver.domain.job.domain.entity.JobEntity;
-import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Department;
-import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Education;
-import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Location;
-import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
+import com.bigtablet.bigtablethompageserver.domain.job.domain.model.JobInput;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.repository.jpa.JobJpaRepository;
 import com.bigtablet.bigtablethompageserver.domain.job.exception.JobNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 
 @Slf4j
 @Service
@@ -23,52 +18,26 @@ public class JobService {
 
     /**
      * 채용 공고 저장
-     * @param title String 공고 제목
-     * @param department Department 부서
-     * @param location Location 근무 지역
-     * @param recruitType RecruitType 채용 유형
-     * @param experiment String 경력 요건
-     * @param education Education 학력 요건
-     * @param companyIntroduction String 회사 소개
-     * @param positionIntroduction String 포지션 소개
-     * @param mainResponsibility String 주요 업무
-     * @param qualification String 자격 요건
-     * @param preferredQualification String 우대 사항
-     * @param startDate LocalDate 공고 시작일
-     * @param endDate LocalDate 공고 마감일
+     * @param input JobInput 채용 공고 입력 데이터
      * @return void
      */
     @Transactional
-    public void save(
-            String title,
-            Department department,
-            Location location,
-            RecruitType recruitType,
-            String experiment,
-            Education education,
-            String companyIntroduction,
-            String positionIntroduction,
-            String mainResponsibility,
-            String qualification,
-            String preferredQualification,
-            LocalDate startDate,
-            LocalDate endDate
-    ) {
-        log.info("[JobService] save - title={}", title);
+    public void save(JobInput input) {
+        log.info("[JobService] save - title={}", input.title());
         jobJpaRepository.save(JobEntity.builder()
-                .title(title)
-                .department(department)
-                .location(location)
-                .recruitType(recruitType)
-                .experiment(experiment)
-                .education(education)
-                .companyIntroduction(companyIntroduction)
-                .positionIntroduction(positionIntroduction)
-                .mainResponsibility(mainResponsibility)
-                .qualification(qualification)
-                .preferredQualification(preferredQualification)
-                .startDate(startDate)
-                .endDate(endDate)
+                .title(input.title())
+                .department(input.department())
+                .location(input.location())
+                .recruitType(input.recruitType())
+                .experiment(input.experiment())
+                .education(input.education())
+                .companyIntroduction(input.companyIntroduction())
+                .positionIntroduction(input.positionIntroduction())
+                .mainResponsibility(input.mainResponsibility())
+                .qualification(input.qualification())
+                .preferredQualification(input.preferredQualification())
+                .startDate(input.startDate())
+                .endDate(input.endDate())
                 .isActive(true)
                 .build());
     }
@@ -76,57 +45,16 @@ public class JobService {
     /**
      * 채용 공고 수정
      * @param idx Long 채용 공고 ID
-     * @param title String 공고 제목
-     * @param department Department 부서
-     * @param location Location 근무 지역
-     * @param recruitType RecruitType 채용 유형
-     * @param experiment String 경력 요건
-     * @param education Education 학력 요건
-     * @param companyIntroduction String 회사 소개
-     * @param positionIntroduction String 포지션 소개
-     * @param mainResponsibility String 주요 업무
-     * @param qualification String 자격 요건
-     * @param preferredQualification String 우대 사항
-     * @param startDate LocalDate 공고 시작일
-     * @param endDate LocalDate 공고 마감일
+     * @param input JobInput 채용 공고 입력 데이터
      * @return void
      */
     @Transactional
-    public void edit(
-            Long idx,
-            String title,
-            Department department,
-            Location location,
-            RecruitType recruitType,
-            String experiment,
-            Education education,
-            String companyIntroduction,
-            String positionIntroduction,
-            String mainResponsibility,
-            String qualification,
-            String preferredQualification,
-            LocalDate startDate,
-            LocalDate endDate
-    ) {
+    public void edit(Long idx, JobInput input) {
         log.info("[JobService] edit - idx={}", idx);
         JobEntity entity = jobJpaRepository
                 .findById(idx)
                 .orElseThrow(() -> JobNotFoundException.EXCEPTION);
-        entity.editJob(
-                title,
-                department,
-                location,
-                recruitType,
-                experiment,
-                education,
-                companyIntroduction,
-                positionIntroduction,
-                mainResponsibility,
-                qualification,
-                preferredQualification,
-                startDate,
-                endDate
-        );
+        entity.editJob(input);
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
@@ -24,22 +24,7 @@ public class JobService {
     @Transactional
     public void save(JobInput input) {
         log.info("[JobService] save - title={}", input.title());
-        jobJpaRepository.save(JobEntity.builder()
-                .title(input.title())
-                .department(input.department())
-                .location(input.location())
-                .recruitType(input.recruitType())
-                .experiment(input.experiment())
-                .education(input.education())
-                .companyIntroduction(input.companyIntroduction())
-                .positionIntroduction(input.positionIntroduction())
-                .mainResponsibility(input.mainResponsibility())
-                .qualification(input.qualification())
-                .preferredQualification(input.preferredQualification())
-                .startDate(input.startDate())
-                .endDate(input.endDate())
-                .isActive(true)
-                .build());
+        jobJpaRepository.save(JobEntity.create(input));
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
@@ -7,6 +7,7 @@ import com.bigtablet.bigtablethompageserver.domain.job.client.dto.request.EditJo
 import com.bigtablet.bigtablethompageserver.domain.job.client.dto.request.GetJobListRequest;
 import com.bigtablet.bigtablethompageserver.domain.job.client.dto.request.RegisterJobRequest;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.model.Job;
+import com.bigtablet.bigtablethompageserver.domain.job.domain.model.JobInput;
 import com.bigtablet.bigtablethompageserver.domain.job.exception.JobIsEmptyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,19 +31,21 @@ public class JobUseCase {
     public void registerJob(RegisterJobRequest request) {
         log.info("[JobUseCase] registerJob - title={}", request.title());
         jobService.save(
-                request.title(),
-                request.department(),
-                request.location(),
-                request.recruitType(),
-                request.experiment(),
-                request.education(),
-                request.companyIntroduction(),
-                request.positionIntroduction(),
-                request.mainResponsibility(),
-                request.qualification(),
-                request.preferredQualification(),
-                request.startDate(),
-                request.endDate()
+                JobInput.builder()
+                        .title(request.title())
+                        .department(request.department())
+                        .location(request.location())
+                        .recruitType(request.recruitType())
+                        .experiment(request.experiment())
+                        .education(request.education())
+                        .companyIntroduction(request.companyIntroduction())
+                        .positionIntroduction(request.positionIntroduction())
+                        .mainResponsibility(request.mainResponsibility())
+                        .qualification(request.qualification())
+                        .preferredQualification(request.preferredQualification())
+                        .startDate(request.startDate())
+                        .endDate(request.endDate())
+                        .build()
         );
     }
 
@@ -103,19 +106,21 @@ public class JobUseCase {
         log.info("[JobUseCase] editJob - idx={}", request.idx());
         jobService.edit(
                 request.idx(),
-                request.title(),
-                request.department(),
-                request.location(),
-                request.recruitType(),
-                request.experiment(),
-                request.education(),
-                request.companyIntroduction(),
-                request.positionIntroduction(),
-                request.mainResponsibility(),
-                request.qualification(),
-                request.preferredQualification(),
-                request.startDate(),
-                request.endDate()
+                JobInput.builder()
+                        .title(request.title())
+                        .department(request.department())
+                        .location(request.location())
+                        .recruitType(request.recruitType())
+                        .experiment(request.experiment())
+                        .education(request.education())
+                        .companyIntroduction(request.companyIntroduction())
+                        .positionIntroduction(request.positionIntroduction())
+                        .mainResponsibility(request.mainResponsibility())
+                        .qualification(request.qualification())
+                        .preferredQualification(request.preferredQualification())
+                        .startDate(request.startDate())
+                        .endDate(request.endDate())
+                        .build()
         );
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
@@ -7,7 +7,6 @@ import com.bigtablet.bigtablethompageserver.domain.job.client.dto.request.EditJo
 import com.bigtablet.bigtablethompageserver.domain.job.client.dto.request.GetJobListRequest;
 import com.bigtablet.bigtablethompageserver.domain.job.client.dto.request.RegisterJobRequest;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.model.Job;
-import com.bigtablet.bigtablethompageserver.domain.job.domain.model.JobInput;
 import com.bigtablet.bigtablethompageserver.domain.job.exception.JobIsEmptyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,23 +29,7 @@ public class JobUseCase {
      */
     public void registerJob(RegisterJobRequest request) {
         log.info("[JobUseCase] registerJob - title={}", request.title());
-        jobService.save(
-                JobInput.builder()
-                        .title(request.title())
-                        .department(request.department())
-                        .location(request.location())
-                        .recruitType(request.recruitType())
-                        .experiment(request.experiment())
-                        .education(request.education())
-                        .companyIntroduction(request.companyIntroduction())
-                        .positionIntroduction(request.positionIntroduction())
-                        .mainResponsibility(request.mainResponsibility())
-                        .qualification(request.qualification())
-                        .preferredQualification(request.preferredQualification())
-                        .startDate(request.startDate())
-                        .endDate(request.endDate())
-                        .build()
-        );
+        jobService.save(request.toJobInput());
     }
 
     /**
@@ -104,24 +87,7 @@ public class JobUseCase {
      */
     public void editJob(EditJobRequest request) {
         log.info("[JobUseCase] editJob - idx={}", request.idx());
-        jobService.edit(
-                request.idx(),
-                JobInput.builder()
-                        .title(request.title())
-                        .department(request.department())
-                        .location(request.location())
-                        .recruitType(request.recruitType())
-                        .experiment(request.experiment())
-                        .education(request.education())
-                        .companyIntroduction(request.companyIntroduction())
-                        .positionIntroduction(request.positionIntroduction())
-                        .mainResponsibility(request.mainResponsibility())
-                        .qualification(request.qualification())
-                        .preferredQualification(request.preferredQualification())
-                        .startDate(request.startDate())
-                        .endDate(request.endDate())
-                        .build()
-        );
+        jobService.edit(request.idx(), request.toJobInput());
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/EditJobRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/EditJobRequest.java
@@ -4,6 +4,7 @@ import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Department;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Education;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Location;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
+import com.bigtablet.bigtablethompageserver.domain.job.domain.model.JobInput;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -37,4 +38,26 @@ public record EditJobRequest(
         @NotNull
         LocalDate startDate,
         LocalDate endDate
-) {}
+) {
+    /**
+     * Request DTO를 JobInput 도메인 입력 데이터로 변환한다 (idx 제외)
+     * @return JobInput 채용 공고 입력 데이터
+     */
+    public JobInput toJobInput() {
+        return new JobInput(
+                title,
+                department,
+                location,
+                recruitType,
+                experiment,
+                education,
+                companyIntroduction,
+                positionIntroduction,
+                mainResponsibility,
+                qualification,
+                preferredQualification,
+                startDate,
+                endDate
+        );
+    }
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/RegisterJobRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/RegisterJobRequest.java
@@ -4,6 +4,7 @@ import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Department;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Education;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Location;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
+import com.bigtablet.bigtablethompageserver.domain.job.domain.model.JobInput;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -36,4 +37,25 @@ public record RegisterJobRequest(
         LocalDate startDate,
         LocalDate endDate
 ) {
+    /**
+     * Request DTO를 JobInput 도메인 입력 데이터로 변환한다
+     * @return JobInput 채용 공고 입력 데이터
+     */
+    public JobInput toJobInput() {
+        return new JobInput(
+                title,
+                department,
+                location,
+                recruitType,
+                experiment,
+                education,
+                companyIntroduction,
+                positionIntroduction,
+                mainResponsibility,
+                qualification,
+                preferredQualification,
+                startDate,
+                endDate
+        );
+    }
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/entity/JobEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/entity/JobEntity.java
@@ -4,6 +4,7 @@ import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Department;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Education;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Location;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
+import com.bigtablet.bigtablethompageserver.domain.job.domain.model.JobInput;
 import com.bigtablet.bigtablethompageserver.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -93,48 +94,22 @@ public class JobEntity extends BaseEntity {
 
     /**
      * 채용 공고 정보를 수정한다
-     * @param title String 공고 제목
-     * @param department Department 부서
-     * @param location Location 근무지
-     * @param recruitType RecruitType 채용 유형
-     * @param experiment String 경력 요건
-     * @param education Education 학력 요건
-     * @param companyIntroduction String 회사 소개
-     * @param positionIntroduction String 포지션 소개
-     * @param mainResponsibility String 주요 업무
-     * @param qualification String 자격 요건
-     * @param preferredQualification String 우대 사항
-     * @param startDate LocalDate 공고 시작일
-     * @param endDate LocalDate 공고 마감일
+     * @param input JobInput 채용 공고 입력 데이터
      */
-    public void editJob(
-            String title,
-            Department department,
-            Location location,
-            RecruitType recruitType,
-            String experiment,
-            Education education,
-            String companyIntroduction,
-            String positionIntroduction,
-            String mainResponsibility,
-            String qualification,
-            String preferredQualification,
-            LocalDate startDate,
-            LocalDate endDate
-    ) {
-        this.title = title;
-        this.department = department;
-        this.location = location;
-        this.recruitType = recruitType;
-        this.experiment = experiment;
-        this.education = education;
-        this.companyIntroduction = companyIntroduction;
-        this.positionIntroduction = positionIntroduction;
-        this.mainResponsibility = mainResponsibility;
-        this.qualification = qualification;
-        this.preferredQualification = preferredQualification;
-        this.startDate = startDate;
-        this.endDate = endDate;
+    public void editJob(JobInput input) {
+        this.title = input.title();
+        this.department = input.department();
+        this.location = input.location();
+        this.recruitType = input.recruitType();
+        this.experiment = input.experiment();
+        this.education = input.education();
+        this.companyIntroduction = input.companyIntroduction();
+        this.positionIntroduction = input.positionIntroduction();
+        this.mainResponsibility = input.mainResponsibility();
+        this.qualification = input.qualification();
+        this.preferredQualification = input.preferredQualification();
+        this.startDate = input.startDate();
+        this.endDate = input.endDate();
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/entity/JobEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/entity/JobEntity.java
@@ -93,6 +93,30 @@ public class JobEntity extends BaseEntity {
     private boolean isActive;
 
     /**
+     * JobInput으로 새 활성 상태 채용 공고 엔티티를 생성한다
+     * @param input JobInput 채용 공고 입력 데이터
+     * @return JobEntity 신규 채용 공고 엔티티
+     */
+    public static JobEntity create(JobInput input) {
+        return JobEntity.builder()
+                .title(input.title())
+                .department(input.department())
+                .location(input.location())
+                .recruitType(input.recruitType())
+                .experiment(input.experiment())
+                .education(input.education())
+                .companyIntroduction(input.companyIntroduction())
+                .positionIntroduction(input.positionIntroduction())
+                .mainResponsibility(input.mainResponsibility())
+                .qualification(input.qualification())
+                .preferredQualification(input.preferredQualification())
+                .startDate(input.startDate())
+                .endDate(input.endDate())
+                .isActive(true)
+                .build();
+    }
+
+    /**
      * 채용 공고 정보를 수정한다
      * @param input JobInput 채용 공고 입력 데이터
      */

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/model/JobInput.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/model/JobInput.java
@@ -1,0 +1,27 @@
+package com.bigtablet.bigtablethompageserver.domain.job.domain.model;
+
+import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Department;
+import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Education;
+import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Location;
+import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record JobInput(
+        String title,
+        Department department,
+        Location location,
+        RecruitType recruitType,
+        String experiment,
+        Education education,
+        String companyIntroduction,
+        String positionIntroduction,
+        String mainResponsibility,
+        String qualification,
+        String preferredQualification,
+        LocalDate startDate,
+        LocalDate endDate
+) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
@@ -6,6 +6,7 @@ import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.Recruit;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.RecruitInput;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.repository.jpa.RecruitJpaRepository;
 import com.bigtablet.bigtablethompageserver.domain.recruit.exception.RecruitNotFoundException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,27 +27,7 @@ public class RecruitService {
     @Transactional
     public Recruit save(RecruitInput input) {
         log.info("[RecruitService] save - jobId={}, name={}", input.jobId(), input.name());
-        RecruitEntity entity = recruitJpaRepository.save(RecruitEntity.builder()
-                .jobId(input.jobId())
-                .name(input.name())
-                .phoneNumber(input.phoneNumber())
-                .email(input.email())
-                .address(input.address())
-                .addressDetail(input.addressDetail())
-                .portfolio(input.portfolio())
-                .coverLetter(input.coverLetter())
-                .profileImage(input.profileImage())
-                .educationLevel(input.educationLevel())
-                .schoolName(input.schoolName())
-                .admissionYear(input.admissionYear())
-                .graduationYear(input.graduationYear())
-                .department(input.department())
-                .military(input.military())
-                .attachment1(input.attachment1())
-                .attachment2(input.attachment2())
-                .attachment3(input.attachment3())
-                .status(Status.DOCUMENT)
-                .build());
+        RecruitEntity entity = recruitJpaRepository.save(RecruitEntity.create(input));
         return Recruit.of(entity);
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
@@ -1,10 +1,9 @@
 package com.bigtablet.bigtablethompageserver.domain.recruit.application.service;
 
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.entity.RecruitEntity;
-import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.EducationLevel;
-import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Military;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Status;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.Recruit;
+import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.RecruitInput;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.repository.jpa.RecruitJpaRepository;
 import com.bigtablet.bigtablethompageserver.domain.recruit.exception.RecruitNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -21,67 +20,31 @@ public class RecruitService {
 
     /**
      * 채용 지원서 저장
-     * @param jobId Long 채용 공고 ID
-     * @param name String 지원자 이름
-     * @param phoneNumber String 전화번호
-     * @param email String 이메일
-     * @param address String 주소
-     * @param addressDetail String 상세 주소
-     * @param portfolio String 포트폴리오 URL
-     * @param coverLetter String 자기소개서
-     * @param profileImage String 프로필 이미지 URL
-     * @param educationLevel EducationLevel 학력 수준
-     * @param schoolName String 학교명
-     * @param admissionYear String 입학 연도
-     * @param graduationYear String 졸업 연도
-     * @param department String 학과
-     * @param military Military 병역 사항
-     * @param attachment1 String 첨부파일 1 URL
-     * @param attachment2 String 첨부파일 2 URL
-     * @param attachment3 String 첨부파일 3 URL
+     * @param input RecruitInput 채용 지원서 입력 데이터
      * @return Recruit 도메인 객체
      */
     @Transactional
-    public Recruit save(
-            Long jobId,
-            String name,
-            String phoneNumber,
-            String email,
-            String address,
-            String addressDetail,
-            String portfolio,
-            String coverLetter,
-            String profileImage,
-            EducationLevel educationLevel,
-            String schoolName,
-            String admissionYear,
-            String graduationYear,
-            String department,
-            Military military,
-            String attachment1,
-            String attachment2,
-            String attachment3
-    ) {
-        log.info("[RecruitService] save - jobId={}, name={}", jobId, name);
+    public Recruit save(RecruitInput input) {
+        log.info("[RecruitService] save - jobId={}, name={}", input.jobId(), input.name());
         RecruitEntity entity = recruitJpaRepository.save(RecruitEntity.builder()
-                .jobId(jobId)
-                .name(name)
-                .phoneNumber(phoneNumber)
-                .email(email)
-                .address(address)
-                .addressDetail(addressDetail)
-                .portfolio(portfolio)
-                .coverLetter(coverLetter)
-                .profileImage(profileImage)
-                .educationLevel(educationLevel)
-                .schoolName(schoolName)
-                .admissionYear(admissionYear)
-                .graduationYear(graduationYear)
-                .department(department)
-                .military(military)
-                .attachment1(attachment1)
-                .attachment2(attachment2)
-                .attachment3(attachment3)
+                .jobId(input.jobId())
+                .name(input.name())
+                .phoneNumber(input.phoneNumber())
+                .email(input.email())
+                .address(input.address())
+                .addressDetail(input.addressDetail())
+                .portfolio(input.portfolio())
+                .coverLetter(input.coverLetter())
+                .profileImage(input.profileImage())
+                .educationLevel(input.educationLevel())
+                .schoolName(input.schoolName())
+                .admissionYear(input.admissionYear())
+                .graduationYear(input.graduationYear())
+                .department(input.department())
+                .military(input.military())
+                .attachment1(input.attachment1())
+                .attachment2(input.attachment2())
+                .attachment3(input.attachment3())
                 .status(Status.DOCUMENT)
                 .build());
         return Recruit.of(entity);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -9,6 +9,7 @@ import com.bigtablet.bigtablethompageserver.domain.recruit.client.dto.request.Ge
 import com.bigtablet.bigtablethompageserver.domain.recruit.client.dto.request.RegisterRecruitRequest;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Status;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.Recruit;
+import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.RecruitInput;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
 import com.bigtablet.bigtablethompageserver.global.infra.slack.exception.SlackErrorException;
@@ -42,24 +43,26 @@ public class RecruitUseCase {
         Job job = jobQueryService.find(request.jobId());
         jobQueryService.checkIsExpired(job);
         Recruit recruit = recruitService.save(
-                job.idx(),
-                request.name(),
-                request.phoneNumber(),
-                request.email(),
-                request.address(),
-                request.addressDetail(),
-                request.portfolio(),
-                request.coverLetter(),
-                request.profileImage(),
-                request.educationLevel(),
-                request.schoolName(),
-                request.admissionYear(),
-                request.graduationYear(),
-                request.department(),
-                request.military(),
-                request.attachment1(),
-                request.attachment2(),
-                request.attachment3()
+                RecruitInput.builder()
+                        .jobId(job.idx())
+                        .name(request.name())
+                        .phoneNumber(request.phoneNumber())
+                        .email(request.email())
+                        .address(request.address())
+                        .addressDetail(request.addressDetail())
+                        .portfolio(request.portfolio())
+                        .coverLetter(request.coverLetter())
+                        .profileImage(request.profileImage())
+                        .educationLevel(request.educationLevel())
+                        .schoolName(request.schoolName())
+                        .admissionYear(request.admissionYear())
+                        .graduationYear(request.graduationYear())
+                        .department(request.department())
+                        .military(request.military())
+                        .attachment1(request.attachment1())
+                        .attachment2(request.attachment2())
+                        .attachment3(request.attachment3())
+                        .build()
         );
         String content = mailTemplateRenderer.renderApplyConfirmEmail(request.name(), job.title(), LocalDateTime.now());
         emailService.sendRecruit(

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -9,7 +9,6 @@ import com.bigtablet.bigtablethompageserver.domain.recruit.client.dto.request.Ge
 import com.bigtablet.bigtablethompageserver.domain.recruit.client.dto.request.RegisterRecruitRequest;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Status;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.Recruit;
-import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.RecruitInput;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
 import com.bigtablet.bigtablethompageserver.global.infra.slack.exception.SlackErrorException;
@@ -42,28 +41,7 @@ public class RecruitUseCase {
         log.info("[RecruitUseCase] registerRecruit - jobId={}, name={}", request.jobId(), request.name());
         Job job = jobQueryService.find(request.jobId());
         jobQueryService.checkIsExpired(job);
-        Recruit recruit = recruitService.save(
-                RecruitInput.builder()
-                        .jobId(job.idx())
-                        .name(request.name())
-                        .phoneNumber(request.phoneNumber())
-                        .email(request.email())
-                        .address(request.address())
-                        .addressDetail(request.addressDetail())
-                        .portfolio(request.portfolio())
-                        .coverLetter(request.coverLetter())
-                        .profileImage(request.profileImage())
-                        .educationLevel(request.educationLevel())
-                        .schoolName(request.schoolName())
-                        .admissionYear(request.admissionYear())
-                        .graduationYear(request.graduationYear())
-                        .department(request.department())
-                        .military(request.military())
-                        .attachment1(request.attachment1())
-                        .attachment2(request.attachment2())
-                        .attachment3(request.attachment3())
-                        .build()
-        );
+        Recruit recruit = recruitService.save(request.toRecruitInput(job.idx()));
         String content = mailTemplateRenderer.renderApplyConfirmEmail(request.name(), job.title(), LocalDateTime.now());
         emailService.sendRecruit(
                 request.email(),

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
@@ -2,6 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.recruit.client.dto.request;
 
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.EducationLevel;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Military;
+import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.RecruitInput;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -52,4 +53,33 @@ public record RegisterRecruitRequest(
         String attachment2,
         @URL(message = "유효한 URL 형식이어야 합니다.")
         String attachment3
-) {}
+) {
+    /**
+     * Request DTO를 RecruitInput 도메인 입력 데이터로 변환한다 (jobId 오버라이드 지원)
+     * @param resolvedJobId Long 검증/조회된 채용 공고 ID
+     * @return RecruitInput 채용 지원서 입력 데이터
+     */
+    public RecruitInput toRecruitInput(Long resolvedJobId) {
+        return new RecruitInput(
+                resolvedJobId,
+                name,
+                phoneNumber,
+                email,
+                address,
+                addressDetail,
+                portfolio,
+                coverLetter,
+                profileImage,
+                educationLevel,
+                schoolName,
+                admissionYear,
+                graduationYear,
+                department,
+                military,
+                attachment1,
+                attachment2,
+                attachment3
+        );
+    }
+}
+

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/entity/RecruitEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/entity/RecruitEntity.java
@@ -3,6 +3,7 @@ package com.bigtablet.bigtablethompageserver.domain.recruit.domain.entity;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.EducationLevel;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Military;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Status;
+import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.RecruitInput;
 import com.bigtablet.bigtablethompageserver.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -100,6 +101,35 @@ public class RecruitEntity extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Status status;
+
+    /**
+     * RecruitInput으로 새 지원서 엔티티를 생성한다 (서류 전형 상태)
+     * @param input RecruitInput 채용 지원서 입력 데이터
+     * @return RecruitEntity 신규 지원서 엔티티
+     */
+    public static RecruitEntity create(RecruitInput input) {
+        return RecruitEntity.builder()
+                .jobId(input.jobId())
+                .name(input.name())
+                .phoneNumber(input.phoneNumber())
+                .email(input.email())
+                .address(input.address())
+                .addressDetail(input.addressDetail())
+                .portfolio(input.portfolio())
+                .coverLetter(input.coverLetter())
+                .profileImage(input.profileImage())
+                .educationLevel(input.educationLevel())
+                .schoolName(input.schoolName())
+                .admissionYear(input.admissionYear())
+                .graduationYear(input.graduationYear())
+                .department(input.department())
+                .military(input.military())
+                .attachment1(input.attachment1())
+                .attachment2(input.attachment2())
+                .attachment3(input.attachment3())
+                .status(Status.DOCUMENT)
+                .build();
+    }
 
     /**
      * 지원서 전형 상태를 변경한다

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/model/RecruitInput.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/model/RecruitInput.java
@@ -1,0 +1,28 @@
+package com.bigtablet.bigtablethompageserver.domain.recruit.domain.model;
+
+import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.EducationLevel;
+import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Military;
+
+import lombok.Builder;
+
+@Builder
+public record RecruitInput(
+        Long jobId,
+        String name,
+        String phoneNumber,
+        String email,
+        String address,
+        String addressDetail,
+        String portfolio,
+        String coverLetter,
+        String profileImage,
+        EducationLevel educationLevel,
+        String schoolName,
+        String admissionYear,
+        String graduationYear,
+        String department,
+        Military military,
+        String attachment1,
+        String attachment2,
+        String attachment3
+) {}


### PR DESCRIPTION
## 제목
fix/long-param-services — RecruitService / JobService 긴 파라미터 리스트 정리

Closes #84

## 작업한 내용
- `domain/recruit/domain/model/RecruitInput` record 추가 (17 필드)
- `domain/job/domain/model/JobInput` record 추가 (13 필드)
- `RecruitService#save(...)` 시그니처 17 params → `RecruitInput`
- `JobService#save(...)` 13 params → `JobInput`
- `JobService#edit(...)` 13 params → `(Long idx, JobInput input)`
- `JobEntity#editJob(...)` 13 params → `JobInput`
- `RecruitUseCase`/`JobUseCase`에서 Request DTO를 Input record로 매핑하여 호출

호출부와 시그니처가 한눈에 들어오도록 정리되었고, 향후 필드 추가 시 record + builder 호출만 수정하면 됨.

## 전달할 추가 이슈
- 본 PR은 `JobUseCase`를 건드리므로 #85(empty-list 헬퍼 추출)와 머지 순서 의존성 있음. #84 → #85 권장.