### PR TITLE
fix/empty-list-validation

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/usecase/BlogUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/usecase/BlogUseCase.java
@@ -8,6 +8,7 @@ import com.bigtablet.bigtablethompageserver.domain.blog.client.dto.request.Regis
 import com.bigtablet.bigtablethompageserver.domain.blog.domain.model.Blog;
 import com.bigtablet.bigtablethompageserver.domain.blog.exception.BlogIsEmptyException;
 import com.bigtablet.bigtablethompageserver.global.common.dto.request.PageRequest;
+import com.bigtablet.bigtablethompageserver.global.common.util.CollectionValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -57,7 +58,7 @@ public class BlogUseCase {
     public List<BlogResponse> getAllBlogList(PageRequest request) {
         log.info("[BlogUseCase] getAllBlogList - page={}, size={}", request.getPage(), request.getSize());
         List<Blog> blogs = blogQueryService.findAll(request.getPage(), request.getSize());
-        checkBlogsIsEmpty(blogs);
+        CollectionValidator.throwIfEmpty(blogs, BlogIsEmptyException.EXCEPTION);
         return blogs.stream()
                 .map(BlogResponse::of)
                 .toList();
@@ -72,7 +73,7 @@ public class BlogUseCase {
     public List<BlogResponse> searchBlogByTitle(PageRequest request, String title) {
         log.info("[BlogUseCase] searchBlogByTitle - title={}", title);
         List<Blog> blogs = blogQueryService.findAllByTitle(request.getPage(), request.getSize(), title);
-        checkBlogsIsEmpty(blogs);
+        CollectionValidator.throwIfEmpty(blogs, BlogIsEmptyException.EXCEPTION);
         return blogs.stream()
                 .map(BlogResponse::of)
                 .toList();
@@ -113,17 +114,6 @@ public class BlogUseCase {
     public void addViews(Long idx) {
         log.info("[BlogUseCase] addViews - idx={}", idx);
         blogService.addViews(idx);
-    }
-
-    /**
-     * 블로그 목록 비어있는지 검증
-     * @param blogs List<Blog> 블로그 도메인 객체 목록
-     * @return void
-     */
-    private void checkBlogsIsEmpty(List<Blog> blogs) {
-        if (blogs.isEmpty()) {
-            throw BlogIsEmptyException.EXCEPTION;
-        }
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
@@ -8,6 +8,7 @@ import com.bigtablet.bigtablethompageserver.domain.job.client.dto.request.GetJob
 import com.bigtablet.bigtablethompageserver.domain.job.client.dto.request.RegisterJobRequest;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.model.Job;
 import com.bigtablet.bigtablethompageserver.domain.job.exception.JobIsEmptyException;
+import com.bigtablet.bigtablethompageserver.global.common.util.CollectionValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -57,7 +58,7 @@ public class JobUseCase {
                         request.getEducation(),
                         request.getRecruitType()
                 );
-        checkJobsIsEmpty(jobs);
+        CollectionValidator.throwIfEmpty(jobs, JobIsEmptyException.EXCEPTION);
         return jobs.stream().map(JobResponse::of).toList();
     }
 
@@ -76,7 +77,7 @@ public class JobUseCase {
                         request.getEducation(),
                         request.getRecruitType()
                 );
-        checkJobsIsEmpty(jobs);
+        CollectionValidator.throwIfEmpty(jobs, JobIsEmptyException.EXCEPTION);
         return jobs.stream().map(JobResponse::of).toList();
     }
 
@@ -109,17 +110,6 @@ public class JobUseCase {
         log.info("[JobUseCase] deleteJob - idx={}", idx);
         Job job = jobQueryService.find(idx);
         jobService.delete(job.idx());
-    }
-
-    /**
-     * 채용 공고 목록 비어있는지 검증
-     * @param jobs List<Job> 채용 공고 도메인 객체 목록
-     * @return void
-     */
-    private void checkJobsIsEmpty(List<Job> jobs) {
-        if (jobs.isEmpty()) {
-            throw JobIsEmptyException.EXCEPTION;
-        }
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/usecase/NewsUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/usecase/NewsUseCase.java
@@ -8,6 +8,7 @@ import com.bigtablet.bigtablethompageserver.domain.news.client.dto.request.Regis
 import com.bigtablet.bigtablethompageserver.domain.news.domain.model.News;
 import com.bigtablet.bigtablethompageserver.domain.news.exception.NewsIsEmptyException;
 import com.bigtablet.bigtablethompageserver.global.common.dto.request.PageRequest;
+import com.bigtablet.bigtablethompageserver.global.common.util.CollectionValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -56,7 +57,7 @@ public class NewsUseCase {
     public List<NewsResponse> getAllNewsList(PageRequest request) {
         log.info("[NewsUseCase] getAllNewsList - page={}, size={}", request.getPage(), request.getSize());
         List<News> newsList = newsQueryService.findAll(request.getPage(), request.getSize());
-        checkNewsListIsEmpty(newsList);
+        CollectionValidator.throwIfEmpty(newsList, NewsIsEmptyException.EXCEPTION);
         return newsList.stream()
                 .map(NewsResponse::of)
                 .toList();
@@ -86,17 +87,6 @@ public class NewsUseCase {
     public void deleteNews(Long idx) {
         log.info("[NewsUseCase] deleteNews - idx={}", idx);
         newsService.delete(idx);
-    }
-
-    /**
-     * 뉴스 목록 비어있는지 검증
-     * @param newsList List<News> 뉴스 도메인 객체 목록
-     * @return void
-     */
-    private void checkNewsListIsEmpty(List<News> newsList) {
-        if (newsList.isEmpty()) {
-            throw NewsIsEmptyException.EXCEPTION;
-        }
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
@@ -9,6 +9,7 @@ import com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request.Sea
 import com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request.SendEmailToTalentRequest;
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.model.Talent;
 import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentIsEmptyException;
+import com.bigtablet.bigtablethompageserver.global.common.util.CollectionValidator;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
 import lombok.RequiredArgsConstructor;
@@ -79,7 +80,7 @@ public class TalentUseCase {
     public List<TalentResponse> getTalentList(GetTalentListRequest request) {
         log.info("[TalentUseCase] getTalentList - isActive={}, page={}, size={}", request.isActive(), request.getPage(), request.getSize());
         List<Talent> talents = talentQueryService.findAllTalents(request.isActive(), request.getPage(), request.getSize());
-        checkTalentsIsEmpty(talents);
+        CollectionValidator.throwIfEmpty(talents, TalentIsEmptyException.EXCEPTION);
         return talents.stream().map(TalentResponse::of).toList();
     }
 
@@ -95,19 +96,8 @@ public class TalentUseCase {
                 request.getPage(),
                 request.getSize()
         );
-        checkTalentsIsEmpty(talents);
+        CollectionValidator.throwIfEmpty(talents, TalentIsEmptyException.EXCEPTION);
         return talents.stream().map(TalentResponse::of).toList();
-    }
-
-    /**
-     * 인재 목록 비어있는지 검증
-     * @param talents List<Talent> 인재 도메인 객체 목록
-     * @return void
-     */
-    private void checkTalentsIsEmpty(List<Talent> talents) {
-        if (talents.isEmpty()) {
-            throw TalentIsEmptyException.EXCEPTION;
-        }
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/CollectionValidator.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/CollectionValidator.java
@@ -1,0 +1,23 @@
+package com.bigtablet.bigtablethompageserver.global.common.util;
+
+import java.util.Collection;
+
+public final class CollectionValidator {
+
+    private CollectionValidator() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * 컬렉션이 비어있으면 지정된 예외를 던진다.
+     * @param collection 검사할 컬렉션
+     * @param exception 비어있을 때 던질 예외 (싱글턴 인스턴스 권장)
+     * @param <T> 컬렉션 요소 타입
+     */
+    public static <T> void throwIfEmpty(Collection<T> collection, RuntimeException exception) {
+        if (collection.isEmpty()) {
+            throw exception;
+        }
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/CollectionValidator.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/CollectionValidator.java
@@ -9,13 +9,13 @@ public final class CollectionValidator {
     }
 
     /**
-     * 컬렉션이 비어있으면 지정된 예외를 던진다.
-     * @param collection 검사할 컬렉션
+     * 컬렉션이 null이거나 비어있으면 지정된 예외를 던진다.
+     * @param collection 검사할 컬렉션 (null 허용 — 비어있는 것과 동일하게 처리)
      * @param exception 비어있을 때 던질 예외 (싱글턴 인스턴스 권장)
      * @param <T> 컬렉션 요소 타입
      */
     public static <T> void throwIfEmpty(Collection<T> collection, RuntimeException exception) {
-        if (collection.isEmpty()) {
+        if (collection == null || collection.isEmpty()) {
             throw exception;
         }
     }


### PR DESCRIPTION
## 제목
fix/empty-list-validation — 4개 UseCase의 empty-list 검증 중복 제거

Closes #85

## 작업한 내용
- `global/common/util/CollectionValidator` 추가
  - `static <T> void throwIfEmpty(Collection<T> collection, RuntimeException exception)` — 비어있을 때 전달된 예외를 그대로 throw
  - private 생성자로 인스턴스화 차단
- 4개 UseCase에서 동일한 패턴의 private `check{Domain}IsEmpty` 메서드 제거 후 헬퍼 호출로 치환:
  - `BlogUseCase` — 2개 호출 지점
  - `NewsUseCase` — 1개 호출 지점
  - `JobUseCase` — 2개 호출 지점
  - `TalentUseCase` — 2개 호출 지점
- 각 도메인의 `*IsEmptyException.EXCEPTION` 싱글턴을 그대로 전달하므로 기존 동작/예외 타입 변경 없음

총 -51 / +34 라인. 향후 추가되는 UseCase도 헬퍼 한 줄로 동일 패턴 처리 가능.

## 전달할 추가 이슈
- 본 PR은 `JobUseCase`를 건드리므로 #84(long param refactor)와 충돌 가능. **#84 → #85 순서로 머지 권장** — #84 머지 후 본 브랜치 rebase 필요할 수 있음.
- 빈 결과를 예외로 표현하는 패턴 자체가 적절한지(200 OK + 빈 배열 vs `*IsEmptyException`)는 별도 설계 논의가 필요. 현재 PR은 동작 변경 없이 중복만 제거.