### PR TITLE
fix/usecase-update-naming

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/usecase/BlogUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/usecase/BlogUseCase.java
@@ -84,8 +84,8 @@ public class BlogUseCase {
      * @param request EditBlogRequest 블로그 수정 요청 정보
      * @return void
      */
-    public void editBlog(EditBlogRequest request) {
-        log.info("[BlogUseCase] editBlog - idx={}", request.idx());
+    public void updateBlog(EditBlogRequest request) {
+        log.info("[BlogUseCase] updateBlog - idx={}", request.idx());
         blogService.edit(
                 request.idx(),
                 request.titleKr(),

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
@@ -76,8 +76,8 @@ public class BlogApiHandler {
 
     @PutMapping
     @ResponseStatus(HttpStatus.OK)
-    public BaseResponse editBlog(@RequestBody @Valid final EditBlogRequest request) {
-        blogUseCase.editBlog(request);
+    public BaseResponse updateBlog(@RequestBody @Valid final EditBlogRequest request) {
+        blogUseCase.updateBlog(request);
         return BaseResponse.ok("수정 성공");
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
@@ -86,8 +86,8 @@ public class JobUseCase {
      * @param request EditJobRequest 채용 공고 수정 요청 정보
      * @return void
      */
-    public void editJob(EditJobRequest request) {
-        log.info("[JobUseCase] editJob - idx={}", request.idx());
+    public void updateJob(EditJobRequest request) {
+        log.info("[JobUseCase] updateJob - idx={}", request.idx());
         jobService.edit(request.idx(), request.toJobInput());
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/api/JobApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/api/JobApiHandler.java
@@ -70,8 +70,8 @@ public class JobApiHandler {
 
     @PutMapping
     @ResponseStatus(HttpStatus.OK)
-    public BaseResponse editJob(@RequestBody @Valid final EditJobRequest request) {
-        jobUseCase.editJob(request);
+    public BaseResponse updateJob(@RequestBody @Valid final EditJobRequest request) {
+        jobUseCase.updateJob(request);
         return BaseResponse.ok("수정 성공");
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/usecase/NewsUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/usecase/NewsUseCase.java
@@ -68,8 +68,8 @@ public class NewsUseCase {
      * @param request EditNewsRequest 뉴스 수정 요청 정보
      * @return void
      */
-    public void editNews(EditNewsRequest request) {
-        log.info("[NewsUseCase] editNews - idx={}", request.idx());
+    public void updateNews(EditNewsRequest request) {
+        log.info("[NewsUseCase] updateNews - idx={}", request.idx());
         newsService.edit(
                 request.idx(),
                 request.titleKr(),

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/api/NewsApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/api/NewsApiHandler.java
@@ -60,8 +60,8 @@ public class NewsApiHandler {
 
     @PutMapping
     @ResponseStatus(HttpStatus.OK)
-    public BaseResponse editNews(@RequestBody @Valid final EditNewsRequest request) {
-        newsUseCase.editNews(request);
+    public BaseResponse updateNews(@RequestBody @Valid final EditNewsRequest request) {
+        newsUseCase.updateNews(request);
         return BaseResponse.ok("수정 성공");
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -95,8 +95,8 @@ public class RecruitUseCase {
      * @param idx Long 지원서 식별자
      * @return void
      */
-    public void editStatus(Status status, Long idx) {
-        log.info("[RecruitUseCase] editStatus - idx={}, status={}", idx, status);
+    public void updateStatus(Status status, Long idx) {
+        log.info("[RecruitUseCase] updateStatus - idx={}, status={}", idx, status);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderRecruitEmail(recruit.name(), status);
         recruitService.editStatus(status, idx);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/api/RecruitApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/api/RecruitApiHandler.java
@@ -32,8 +32,8 @@ public class RecruitApiHandler {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public BaseResponse registerRecruit(@RequestBody @Valid final RegisterRecruitRequest registerRecruitRequest) {
-        recruitUseCase.registerRecruit(registerRecruitRequest);
+    public BaseResponse registerRecruit(@RequestBody @Valid final RegisterRecruitRequest request) {
+        recruitUseCase.registerRecruit(request);
         return BaseResponse.created("등록 성공");
     }
 
@@ -57,13 +57,13 @@ public class RecruitApiHandler {
 
     @PatchMapping
     @ResponseStatus(HttpStatus.OK)
-    public BaseResponse editStatus(
+    public BaseResponse updateStatus(
             @RequestParam @NotNull
             final Status status,
             @RequestParam @NotNull
             final Long idx
     ) {
-        recruitUseCase.editStatus(status, idx);
+        recruitUseCase.updateStatus(status, idx);
         return BaseResponse.ok("수정 성공");
     }
 


### PR DESCRIPTION
## 제목
fix/usecase-update-naming — UseCase update 동사 + Request DTO 파라미터 네이밍 정렬

## 작업한 내용
`.claude/layer-conventions.md`의 Method Naming by Layer 표:

| Action | UseCase | Service | Entity |
|--------|---------|---------|--------|
| Update | **`update`** | `edit` | `edit{Field}` |

4개 UseCase가 Update 동사로 Service 쪽 표현인 `edit*`을 쓰고 있었음 — UseCase 동사인 `update*`로 정렬. ApiHandler 메서드명도 호출하는 UseCase와 통일했고 HTTP 경로(`@PatchMapping`/`@PutMapping`)는 그대로 유지되어 클라이언트 contract 변경 없음.

### UseCase + ApiHandler 메서드 rename (8건)
| 도메인 | UseCase | ApiHandler |
|---|---|---|
| recruit | `editStatus` → `updateStatus` | `editStatus` → `updateStatus` |
| blog | `editBlog` → `updateBlog` | `editBlog` → `updateBlog` |
| news | `editNews` → `updateNews` | `editNews` → `updateNews` |
| job | `editJob` → `updateJob` | `editJob` → `updateJob` |

### Request 파라미터 네이밍 (1건)
- `RecruitApiHandler#registerRecruit`의 `RegisterRecruitRequest registerRecruitRequest` → **`request`**
- 다른 13개 ApiHandler 메서드는 모두 단일 Request 파라미터를 `request`로 받음 — 1곳만 옛 스타일이라 통일.

## 전달할 추가 이슈
- 본 PR은 컨벤션 정렬만 다룸. 별도로 식별된 컨벤션 drift:
  - `AuthService.checkPassword` / `checkAuthNum` — Service에 query-style `check*` 메서드 (CQS drift). `AuthQueryService` 분리 또는 stateless validator 추출 필요 — 별도 티켓 권장.
  - `GcpService.checkFileIsEmpty` / `checkFileType` — global infra라 도메인 룰 적용 약함, 그대로 둬도 무방.
  - QueryService `findAll` 명명 불일치 (`findAllRecruits` vs `findAll` vs `findJobList` 혼재) — Low severity.
  - `UserUseCase.get()` 무자격 — 다른 UseCase는 `get{Domain}` 형태.