### PR TITLE
fix/queryservice-readonly-transactional

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/query/BlogQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/query/BlogQueryService.java
@@ -7,11 +7,13 @@ import com.bigtablet.bigtablethompageserver.domain.blog.domain.repository.query.
 import com.bigtablet.bigtablethompageserver.domain.blog.exception.BlogNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class BlogQueryService {
 
     private final BlogJpaRepository blogJpaRepository;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/query/JobQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/query/JobQueryService.java
@@ -11,11 +11,13 @@ import com.bigtablet.bigtablethompageserver.domain.job.exception.JobIsExpiredExc
 import com.bigtablet.bigtablethompageserver.domain.job.exception.JobNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class JobQueryService {
 
     private final JobJpaRepository jobJpaRepository;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/query/NewsQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/query/NewsQueryService.java
@@ -7,11 +7,13 @@ import com.bigtablet.bigtablethompageserver.domain.news.domain.repository.query.
 import com.bigtablet.bigtablethompageserver.domain.news.exception.NewsNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class NewsQueryService {
 
     private final NewsJpaRepository newsJpaRepository;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/query/RecruitQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/query/RecruitQueryService.java
@@ -9,11 +9,13 @@ import com.bigtablet.bigtablethompageserver.domain.recruit.exception.RecruitNotF
 import com.bigtablet.bigtablethompageserver.domain.recruit.exception.RecruitStatusErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RecruitQueryService {
 
     private final RecruitJpaRepository recruitJpaRepository;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/query/TalentQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/query/TalentQueryService.java
@@ -7,11 +7,13 @@ import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentAlread
 import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TalentQueryService {
 
     private final TalentJpaRepository talentJpaRepository;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/application/query/UserQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/application/query/UserQueryService.java
@@ -7,9 +7,11 @@ import com.bigtablet.bigtablethompageserver.domain.user.exception.UserNotFoundEx
 import com.bigtablet.bigtablethompageserver.global.common.repository.user.UserSecurity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserQueryService {
 
     private final UserJpaRepository userJpaRepository;


### PR DESCRIPTION
## 제목
fix/queryservice-readonly-transactional — 6개 QueryService에 readOnly 트랜잭션 적용

Closes #93

## 작업한 내용
6개 QueryService(`Recruit`, `Job`, `Blog`, `News`, `Talent`, `User`) 클래스 레벨에 `@Transactional(readOnly = true)` 추가.

읽기 전용임에도 트랜잭션 경계가 없어 Hibernate가 영속성 컨텍스트에 entity 스냅샷을 유지하고 dirty-checking을 수행하던 상태. 이번 변경으로:
- Hibernate가 스냅샷/dirty-check 스킵 → 메모리/CPU 절감
- JDBC connection의 `setReadOnly(true)` 힌트 → 일부 드라이버 최적화 활용
- 레이어 의도(read-only)가 클래스 시그니처에 명시됨

어노테이션 순서 컨벤션(`shortest → longest`)에 따라 `@Transactional(readOnly = true)`이 가장 길어 마지막 위치.

## 전달할 추가 이슈
- 동작 변경 없음, 모든 메서드는 기존과 동일하게 호출 가능