### PR TITLE
fix/recruit-usecase-duplicate-query

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/query/RecruitQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/query/RecruitQueryService.java
@@ -52,14 +52,11 @@ public class RecruitQueryService {
 
     /**
      * 지원서 상태 검증 (서류 전형 상태인 경우 예외 발생)
-     * @param idx Long 지원서 ID
+     * @param recruit Recruit 검증할 지원서 도메인 객체
      * @return void
      */
-    public void checkStatus(Long idx) {
-        RecruitEntity entity = recruitJpaRepository
-                .findById(idx)
-                .orElseThrow(() -> RecruitNotFoundException.EXCEPTION);
-        if (entity.getStatus().equals(Status.DOCUMENT)) {
+    public void checkStatus(Recruit recruit) {
+        if (recruit.status().equals(Status.DOCUMENT)) {
             throw RecruitStatusErrorException.EXCEPTION;
         }
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -119,7 +119,7 @@ public class RecruitUseCase {
         log.info("[RecruitUseCase] acceptRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderAcceptEmail(recruit.name());
-        recruitQueryService.checkStatus(recruit.idx());
+        recruitQueryService.checkStatus(recruit);
         recruitService.accept(recruit.idx());
         emailService.sendRecruit(
                 recruit.email(),

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -16,6 +16,7 @@ import com.bigtablet.bigtablethompageserver.global.infra.slack.service.SlackNoti
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -95,6 +96,7 @@ public class RecruitUseCase {
      * @param idx Long 지원서 식별자
      * @return void
      */
+    @Transactional
     public void updateStatus(Status status, Long idx) {
         log.info("[RecruitUseCase] updateStatus - idx={}, status={}", idx, status);
         Recruit recruit = recruitQueryService.find(idx);
@@ -112,6 +114,7 @@ public class RecruitUseCase {
      * @param idx Long 지원서 식별자
      * @return void
      */
+    @Transactional
     public void acceptRecruit(Long idx) {
         log.info("[RecruitUseCase] acceptRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);
@@ -130,6 +133,7 @@ public class RecruitUseCase {
      * @param idx Long 지원서 식별자
      * @return void
      */
+    @Transactional
     public void rejectRecruit(Long idx) {
         log.info("[RecruitUseCase] rejectRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);


### PR DESCRIPTION
## 제목
fix/recruit-usecase-duplicate-query — 지원서 상태 변경 경로의 중복 SELECT 제거

Closes #94

## 작업한 내용
`updateStatus` / `acceptRecruit` / `rejectRecruit` 3개 메서드에 `@Transactional` 추가.

기존에는 UseCase에 트랜잭션 경계가 없어 Service / QueryService 호출이 각각 별도 영속성 컨텍스트를 시작 → 같은 row를 매번 다시 SELECT 하던 상태:

| 메서드 | 변경 전 SELECT 수 | 변경 후 SELECT 수 |
|---|---|---|
| `updateStatus` | 2 (find + editStatus.findById) | **1** + UPDATE |
| `acceptRecruit` | 3 (find + checkStatus.findById + accept.findById) | **1** + UPDATE |
| `rejectRecruit` | 2 (find + reject.findById) | **1** + UPDATE |

이제 모든 내부 호출이 1차 캐시를 공유 → 두 번째/세 번째 `findById`가 cache hit.

Email / Slack 알림은 모두 `@Async`라 트랜잭션 내부 호출도 즉시 반환되어 DB 커넥션을 잡지 않음. 안전.

## 전달할 추가 이슈
- 다른 도메인(`Blog`, `News`, `Job`, `Talent`)에서 비슷한 UseCase + Service 분리 + 중복 조회 패턴 점검 필요 (별도 티켓)
- 좀 더 깊이 정리하려면 Service 시그니처를 `(Long idx, ...)` → `(Entity entity, ...)`로 바꿔 `findById` 자체를 호출하지 않도록 하는 방법도 있음. 이번 PR scope는 트랜잭션 경계만.