### PR TITLE
fix/user-exists-by-email

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/application/query/UserQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/application/query/UserQueryService.java
@@ -43,7 +43,7 @@ public class UserQueryService {
      * @return void
      */
     public void checkEmailExists(String email) {
-        if (userJpaRepository.findByEmail(email).isPresent()) {
+        if (userJpaRepository.existsByEmail(email)) {
             throw UserAlreadyExistException.EXCEPTION;
         }
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/application/query/UserQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/application/query/UserQueryService.java
@@ -43,7 +43,7 @@ public class UserQueryService {
      * @return void
      */
     public void checkEmailExists(String email) {
-        if (userJpaRepository.existsByEmail(email)) {
+        if (userJpaRepository.existsByEmailIgnoreCase(email)) {
             throw UserAlreadyExistException.EXCEPTION;
         }
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/domain/repository/jpa/UserJpaRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/domain/repository/jpa/UserJpaRepository.java
@@ -9,6 +9,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, String> {
 
     Optional<UserEntity> findByEmail(String email);
 
-    boolean existsByEmail(String email);
+    boolean existsByEmailIgnoreCase(String email);
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/domain/repository/jpa/UserJpaRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/user/domain/repository/jpa/UserJpaRepository.java
@@ -9,4 +9,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, String> {
 
     Optional<UserEntity> findByEmail(String email);
 
+    boolean existsByEmail(String email);
+
 }


### PR DESCRIPTION
## 제목
fix/user-exists-by-email — User 이메일 중복 체크 SELECT 비용 절감

Closes #95

## 작업한 내용
- `UserJpaRepository`에 `boolean existsByEmail(String email)` derived query 추가
- `UserQueryService.checkEmailExists`가 `findByEmail(...).isPresent()` 대신 `existsByEmail(...)` 호출

기존 패턴은 전체 `UserEntity`를 hydrate한 후 `Optional.isPresent()` 만 보고 버리는 구조 → Spring Data가 `SELECT 1`(또는 `COUNT`)로 단순화하도록 변경. `TalentJpaRepository`는 이미 같은 패턴(`existsByEmail`)을 쓰고 있어 도메인 간 일관성도 맞춰짐.

## 전달할 추가 이슈
- 없음 (단순 derived query 추가)