### PR TITLE
fix/talent-etc-url-fetch

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/entity/TalentEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/entity/TalentEntity.java
@@ -14,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.List;
 
@@ -45,8 +46,9 @@ public class TalentEntity extends BaseEntity {
     @Column(nullable = false)
     private String portfolioUrl;
 
-    // 기타 URL 목록
+    // 기타 URL 목록 (페이지 단위로 묶어 로드해 N+1 회피)
     @ElementCollection
+    @BatchSize(size = 100)
     @CollectionTable(
             name = "tb_url",
             joinColumns = @JoinColumn(name = "talent_id")


### PR DESCRIPTION
## 제목
fix/talent-etc-url-fetch — `Talent.etcUrl` N+1 회피

Closes #97

## 작업한 내용
`TalentEntity.etcUrl` (`@ElementCollection`, `tb_url` 별도 테이블)에 `@BatchSize(size = 100)` 추가.

기존: `Talent.of(entity)` 변환에서 `entity.getEtcUrl()`이 호출되며 talent 한 행마다 `tb_url` 추가 SELECT → 페이지 단위 list / search에서 N+1 발생.

변경 후: Hibernate가 lazy fetch를 묶어 `SELECT * FROM tb_url WHERE talent_id IN (?, ?, ...)` 한 방으로 처리. 페이지 크기 ≤ 100이면 페이지당 collection 추가 SELECT는 **1회로 고정**.

QueryDSL `leftJoin(...).fetchJoin()`도 가능하지만 `@ElementCollection` 자체는 association이 아니라서 Q-class 트리 구조가 어색해짐 — `@BatchSize`는 Hibernate 레이어에서 동일 효과를 내는 1줄 변경이라 채택.

어노테이션 순서는 컨벤션(shortest → longest):
```
@ElementCollection      (18)
@BatchSize(size = 100)  (22)
@CollectionTable(...)   (multi-line, 가장 김)
```

## 전달할 추가 이슈
- 페이지 크기가 100을 초과하면 batch가 분할되어 추가 round-trip 발생. 현재 admin UI 페이지 크기 정책 확인 필요. 100 초과를 자주 쓰면 `@BatchSize` 값 또는 `@Fetch(SUBSELECT)` 검토.
- list / search 화면에서 `etcUrl`이 실제로 노출되지 않는다면 collection 자체를 projection에서 제외하는 쪽이 더 깔끔. 프론트와 협의 필요.
- `tb_url`에 `talent_id` 인덱스 존재 여부 확인 (없으면 batch 쿼리도 풀 스캔).