### PR TITLE
config/security-patches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.5'
+    id 'org.springframework.boot' version '4.0.6'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -27,8 +27,9 @@ repositories {
 ext {
     querydslVersion = "7.1"
     set('tomcat.version', '11.0.21')
-    set('thymeleaf.version', '3.1.4.RELEASE')
+    set('thymeleaf.version', '3.1.5.RELEASE')
     set('jackson-bom.version', '3.1.2')
+    set('netty.version', '4.2.13.Final')
 }
 
 dependencies {


### PR DESCRIPTION
## 제목
config/security-patches — Dependabot 14건 보안 취약점 일괄 해결

## 작업한 내용
`build.gradle`에서 3개 항목만 바꿔 14개 Dependabot 알람을 모두 해결:

```diff
- id 'org.springframework.boot' version '4.0.5'
+ id 'org.springframework.boot' version '4.0.6'

- set('thymeleaf.version', '3.1.4.RELEASE')
+ set('thymeleaf.version', '3.1.5.RELEASE')

+ set('netty.version', '4.2.13.Final')
```

### 해결되는 알람 (14건)

| Severity | # | 패키지 | 적용 후 버전 | 해결 경로 |
|---|---|---|---|---|
| 🔴 Critical | 53 | `spring-boot` | 4.0.6 | plugin bump |
| 🔴 Critical | 52 | `thymeleaf-spring6` | 3.1.5 | ext bump |
| 🔴 Critical | 51 | `thymeleaf` | 3.1.5 | ext bump |
| 🟠 High | 57 | `netty-codec-dns` | 4.2.13 | netty.version override |
| 🟠 High | 54 | `spring-boot` | 4.0.6 | plugin bump |
| 🟠 High | 50 | `spring-security-config` | 7.0.5 | Spring Boot 4.0.6 BOM |
| 🟠 High | 49 | `spring-security-config` | 7.0.5 | Spring Boot 4.0.6 BOM |
| 🟠 High | 32 | `jackson-core` | 3.1.2 | (이미 fixed line, stale alert) |
| 🟡 Medium | 56 | `spring-webmvc` | 7.0.7 | Spring Boot 4.0.6 BOM |
| 🟡 Medium | 47 | `spring-security-web` | 7.0.5 | Spring Boot 4.0.6 BOM |
| 🟡 Medium | 46 | `spring-security-core` | 7.0.5 | Spring Boot 4.0.6 BOM |
| 🟡 Medium | 3 | `commons-lang3` | 3.19.0 | Spring Boot 4.0.6 BOM |
| 🟢 Low | 55 | `spring-webmvc` | 7.0.7 | Spring Boot 4.0.6 BOM |
| 🟢 Low | 48 | `spring-security-core` | 7.0.5 | Spring Boot 4.0.6 BOM |

### 검증
- `./gradlew build -x test` 통과
- `./gradlew dependencies` 결과로 netty/security/webmvc/jackson/commons 전부 fixed 버전으로 resolution 확인

### Spring Boot 4.0.6에 포함되지 않은 부분 — netty
Spring Boot 4.0.6은 여전히 netty BOM 4.2.12를 지정 → `lettuce-core`를 거쳐 `netty-codec-dns:4.2.12`가 들어옴. 알람 #57은 4.2.13.Final 이상에서만 해결되므로 `ext.set('netty.version', '4.2.13.Final')`로 강제. spring-boot-dependency-management plugin이 모든 io.netty:* 모듈에 적용함.

## 전달할 추가 이슈
- Dependabot의 `PR #79` (`spring-boot 4.0.5 → 4.0.6`, base가 main이었음)는 close 처리 — 본 PR이 develop 베이스로 동일+α 패치 수행
- 본 PR 머지 후 develop→main release PR을 한 번 더 만들어야 보안 패치가 main까지 반영됨 (버전 bump는 사용자 수동 처리 예정)