### PR TITLE
fix/talent-edit-active-on-entity

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
@@ -57,11 +57,7 @@ public class TalentService {
         TalentEntity entity = talentJpaRepository
                 .findById(idx)
                 .orElseThrow(() -> TalentNotFoundException.EXCEPTION);
-        if (isActive) {
-            entity.activate();
-        } else {
-            entity.deactivate();
-        }
+        entity.editActive(isActive);
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/entity/TalentEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/entity/TalentEntity.java
@@ -60,17 +60,11 @@ public class TalentEntity extends BaseEntity {
     private boolean isActive;
 
     /**
-     * 인재를 활성화한다
+     * 인재의 활성 상태를 변경한다
+     * @param isActive boolean 활성 여부
      */
-    public void activate() {
-        this.isActive = true;
-    }
-
-    /**
-     * 인재를 비활성화한다
-     */
-    public void deactivate() {
-        this.isActive = false;
+    public void editActive(boolean isActive) {
+        this.isActive = isActive;
     }
 
 }


### PR DESCRIPTION
## 제목
fix/talent-edit-active-on-entity — 마지막 남은 Service-side 상태 전이 분기를 entity로 이관

## 작업한 내용
7개 도메인 전수 조사 결과, 상태 전이 결정 로직(if/else 분기)이 Service에 남아있는 곳은 `TalentService.editActive` 한 곳뿐이었음:

```java
// before
if (isActive) {
    entity.activate();
} else {
    entity.deactivate();
}
```

→ `TalentEntity.editActive(boolean)` 단일 메서드로 통합. `activate()` / `deactivate()`는 위 분기에서만 호출되던 좁은 메서드라 함께 정리.

```java
// after — Service
entity.editActive(isActive);   // 1줄 위임

// after — Entity
public void editActive(boolean isActive) {
    this.isActive = isActive;
}
```

이로써 모든 Service의 mutation 메서드가 **load-then-delegate** 패턴으로 일관됨:
| Service | 상태 전이 위임 대상 |
|---|---|
| `RecruitService` | `entity.editStatus / accept / reject` |
| `JobService` | `entity.editJob / deactivate` |
| `BlogService` | `entity.editBlog / addViews` |
| `NewsService` | `entity.editNews` |
| **`TalentService`** | **`entity.editActive`** ← 본 PR |

이제 어떤 Service도 entity 내부 상태에 대한 분기 결정을 직접 하지 않음.

## 전달할 추가 이슈
- 메서드명 `editActive(boolean)`은 컨벤션 표(`Entity = edit{Field}`)와 일관됨
- `activate()` / `deactivate()` 제거는 **사용처 0건 확인 후** 진행 (`grep` 검증)