### PR TITLE
fix/auth-query-service-split

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/query/AuthQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/query/AuthQueryService.java
@@ -7,12 +7,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.util.Objects;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthQueryService {
 
     private final PasswordEncoder passwordEncoder;
@@ -39,7 +39,7 @@ public class AuthQueryService {
     public void checkAuthNum(String email, String authCode) {
         log.info("[AuthQueryService] checkAuthNum - email={}", email);
         String code = redisRepository.getByKey(email, String.class);
-        if (!Objects.equals(code, authCode)) {
+        if (code == null || !code.equals(authCode)) {
             throw EmailCodeValidException.EXCEPTION;
         }
         redisRepository.delete(email);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/query/AuthQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/query/AuthQueryService.java
@@ -1,0 +1,48 @@
+package com.bigtablet.bigtablethompageserver.domain.auth.application.query;
+
+import com.bigtablet.bigtablethompageserver.domain.user.exception.PasswordWrongException;
+import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
+import com.bigtablet.bigtablethompageserver.global.infra.email.exception.EmailCodeValidException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthQueryService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final RedisRepository redisRepository;
+
+    /**
+     * 비밀번호 일치 여부 검증 (불일치 시 예외 발생)
+     * @param rawPassword String 평문 비밀번호
+     * @param hashedPassword String 해시된 비밀번호
+     * @return void
+     */
+    public void checkPassword(String rawPassword, String hashedPassword) {
+        if (!passwordEncoder.matches(rawPassword, hashedPassword)) {
+            throw PasswordWrongException.EXCEPTION;
+        }
+    }
+
+    /**
+     * 이메일 인증 코드 검증 (불일치 시 예외 발생, 일치 시 일회성 코드를 Redis에서 제거)
+     * @param email String 사용자 이메일
+     * @param authCode String 인증 코드
+     * @return void
+     */
+    public void checkAuthNum(String email, String authCode) {
+        log.info("[AuthQueryService] checkAuthNum - email={}", email);
+        String code = redisRepository.getByKey(email, String.class);
+        if (!Objects.equals(code, authCode)) {
+            throw EmailCodeValidException.EXCEPTION;
+        }
+        redisRepository.delete(email);
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/service/AuthService.java
@@ -2,19 +2,15 @@ package com.bigtablet.bigtablethompageserver.domain.auth.application.service;
 
 import com.bigtablet.bigtablethompageserver.domain.auth.domain.model.AccessToken;
 import com.bigtablet.bigtablethompageserver.domain.auth.domain.model.AuthToken;
-import com.bigtablet.bigtablethompageserver.domain.user.exception.PasswordWrongException;
 import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
-import com.bigtablet.bigtablethompageserver.global.infra.email.exception.EmailCodeValidException;
 import com.bigtablet.bigtablethompageserver.global.security.jwt.JwtProvider;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -24,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 public class AuthService {
 
     private final JwtProvider jwtProvider;
-    private final PasswordEncoder passwordEncoder;
     private final RedisRepository redisRepository;
 
     /**
@@ -49,33 +44,6 @@ public class AuthService {
         log.info("[AuthService] refreshToken");
         Jws<Claims> claims = jwtProvider.getClaims(refreshToken);
         return new AccessToken(jwtProvider.generateAccessToken(claims.getBody().getSubject()));
-    }
-
-    /**
-     * 비밀번호 일치 여부 검증
-     * @param rawPassword String 평문 비밀번호
-     * @param hashedPassword String 해시된 비밀번호
-     * @return void
-     */
-    public void checkPassword(String rawPassword, String hashedPassword) {
-        if (!passwordEncoder.matches(rawPassword, hashedPassword)) {
-            throw PasswordWrongException.EXCEPTION;
-        }
-    }
-
-    /**
-     * 이메일 인증 코드 검증 (Redis 기반)
-     * @param email String 사용자 이메일
-     * @param authCode String 인증 코드
-     * @return void
-     */
-    public void checkAuthNum(String email, String authCode) {
-        log.info("[AuthService] checkAuthNum - email={}", email);
-        String code = redisRepository.getByKey(email, String.class);
-        if (!Objects.equals(code, authCode)) {
-            throw EmailCodeValidException.EXCEPTION;
-        }
-        redisRepository.delete(email);
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/usecase/AuthUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/usecase/AuthUseCase.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.domain.auth.application.usecase;
 
+import com.bigtablet.bigtablethompageserver.domain.auth.application.query.AuthQueryService;
 import com.bigtablet.bigtablethompageserver.domain.auth.application.response.JsonWebTokenResponse;
 import com.bigtablet.bigtablethompageserver.domain.auth.application.response.RefreshTokenResponse;
 import com.bigtablet.bigtablethompageserver.domain.auth.application.service.AuthService;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 public class AuthUseCase {
 
     private final AuthService authService;
+    private final AuthQueryService authQueryService;
     private final UserService userService;
     private final UserQueryService userQueryService;
     private final EmailService emailService;
@@ -51,7 +53,7 @@ public class AuthUseCase {
     public JsonWebTokenResponse signIn(SignInRequest request) {
         log.info("[AuthUseCase] signIn - email={}", request.email());
         User user = userQueryService.find(request.email());
-        authService.checkPassword(request.password(), user.password());
+        authQueryService.checkPassword(request.password(), user.password());
         return JsonWebTokenResponse.of(authService.generateToken(request.email()));
     }
 
@@ -85,7 +87,7 @@ public class AuthUseCase {
      */
     public void checkAuthCode(String email, String authCode) {
         log.info("[AuthUseCase] checkAuthCode - email={}", email);
-        authService.checkAuthNum(email, authCode);
+        authQueryService.checkAuthNum(email, authCode);
     }
 
 }


### PR DESCRIPTION
## 제목
fix/auth-query-service-split — `AuthService`의 validator 메서드들을 `AuthQueryService`로 분리 (CQS 정렬)

## 작업한 내용
`AuthService`(command 영역)에 query-style validator 두 개가 섞여 있던 CQS drift 해소:

- ❌ `AuthService.checkPassword(raw, hashed)` — Service에 위치
- ❌ `AuthService.checkAuthNum(email, code)` — Service에 위치

→ 새 `AuthQueryService`로 이관:
- ✅ `AuthQueryService.checkPassword(...)` 
- ✅ `AuthQueryService.checkAuthNum(...)`

### 변경 파일
- **신규**: `domain/auth/application/query/AuthQueryService.java`
- `AuthService`:
  - `checkPassword`, `checkAuthNum` 제거
  - `PasswordEncoder` 의존성 제거 (더 이상 사용 안 함)
  - 유지: `generateToken`, `refreshToken`, `createRandomNum`
- `AuthUseCase`:
  - `AuthQueryService` 주입 추가
  - `authService.checkPassword/checkAuthNum` 호출을 `authQueryService.~`로 변경

이로써 7개 도메인 모두 **Service = command, QueryService = query/check** 규칙 일관 적용.

### checkAuthNum의 일회성 코드 삭제 처리에 대한 노트
`checkAuthNum`은 검증 성공 시 Redis에서 코드를 삭제하는 cleanup 동작 포함 — 엄밀한 CQS 시각에서는 query 안에 write가 있는 셈. 다만 이 삭제는 **검증과 분리할 수 없는 atomic cleanup** (일회성 OTP 보안 모델). UseCase가 별도 호출로 분리하면 race window 발생 가능 → 현재처럼 query 메서드 내부에 묶어둠.

## 전달할 추가 이슈
- `AuthQueryService`에 `@Transactional(readOnly = true)`를 적용할지 여부는 별도 검토. Redis-only이라 JPA 트랜잭션 영향은 없지만 컨벤션 일관성 측면에서 추가 가능.