### PR TITLE
fix/misc-cleanup-blog-news-gcp-auth

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/service/AuthService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/auth/application/service/AuthService.java
@@ -19,6 +19,9 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class AuthService {
 
+    // 이메일 인증 코드 Redis TTL (초 단위)
+    private static final int AUTH_CODE_TTL_SECONDS = 180;
+
     private final JwtProvider jwtProvider;
     private final RedisRepository redisRepository;
 
@@ -61,7 +64,7 @@ public class AuthService {
             randomNumber.append(r.nextInt(10));
         }
         String authcode = randomNumber.toString();
-        redisRepository.save(email, authcode, 180, TimeUnit.SECONDS);
+        redisRepository.save(email, authcode, AUTH_CODE_TTL_SECONDS, TimeUnit.SECONDS);
         return authcode;
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
@@ -74,10 +74,10 @@ public class BlogService {
     @Transactional
     public void delete(Long idx) {
         log.info("[BlogService] delete - idx={}", idx);
-        if (!blogJpaRepository.existsById(idx)) {
-            throw BlogNotFoundException.EXCEPTION;
-        }
-        blogJpaRepository.deleteById(idx);
+        BlogEntity entity = blogJpaRepository
+                .findById(idx)
+                .orElseThrow(() -> BlogNotFoundException.EXCEPTION);
+        blogJpaRepository.delete(entity);
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
@@ -74,10 +74,10 @@ public class BlogService {
     @Transactional
     public void delete(Long idx) {
         log.info("[BlogService] delete - idx={}", idx);
-        BlogEntity entity = blogJpaRepository
-                .findById(idx)
-                .orElseThrow(() -> BlogNotFoundException.EXCEPTION);
-        blogJpaRepository.deleteById(entity.getIdx());
+        if (!blogJpaRepository.existsById(idx)) {
+            throw BlogNotFoundException.EXCEPTION;
+        }
+        blogJpaRepository.deleteById(idx);
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/service/NewsService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/service/NewsService.java
@@ -58,8 +58,10 @@ public class NewsService {
     @Transactional
     public void delete(Long idx) {
         log.info("[NewsService] delete - idx={}", idx);
-        NewsEntity entity = getNewsEntity(idx);
-        newsJpaRepository.deleteById(entity.getIdx());
+        if (!newsJpaRepository.existsById(idx)) {
+            throw NewsNotFoundException.EXCEPTION;
+        }
+        newsJpaRepository.deleteById(idx);
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/service/NewsService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/service/NewsService.java
@@ -58,10 +58,8 @@ public class NewsService {
     @Transactional
     public void delete(Long idx) {
         log.info("[NewsService] delete - idx={}", idx);
-        if (!newsJpaRepository.existsById(idx)) {
-            throw NewsNotFoundException.EXCEPTION;
-        }
-        newsJpaRepository.deleteById(idx);
+        NewsEntity entity = getNewsEntity(idx);
+        newsJpaRepository.delete(entity);
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/gcp/service/GcpService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/gcp/service/GcpService.java
@@ -98,7 +98,7 @@ public class GcpService {
      * 파일 비어있는지 검증
      * @param multipartFile MultipartFile 검증할 파일
      */
-    public void checkFileIsEmpty(MultipartFile multipartFile) {
+    private void checkFileIsEmpty(MultipartFile multipartFile) {
         if (multipartFile.isEmpty()) {
             throw FileIsEmptyException.EXCEPTION;
         }
@@ -108,7 +108,7 @@ public class GcpService {
      * 허용된 파일 타입인지 검증 (PDF, PNG, JPG, JPEG, MP4)
      * @param contentType String 파일 콘텐츠 타입
      */
-    public void checkFileType(String contentType) {
+    private void checkFileType(String contentType) {
         if (
                 !contentType.equalsIgnoreCase("application/pdf") &&
                 !contentType.equalsIgnoreCase("image/png") &&


### PR DESCRIPTION
## 제목
fix/misc-cleanup-blog-news-gcp-auth — 잡정리 묶음 (Blog/News delete 정리 + GcpService private + AuthService 매직넘버 상수화)

## 작업한 내용
스캔에서 식별된 작은 drift 3건을 한 PR로 묶음 (각각 한두 줄 변경):

### 1. `BlogService.delete()` / `NewsService.delete()` 의미 없는 row hydration
**before**:
```java
BlogEntity entity = blogJpaRepository
        .findById(idx)
        .orElseThrow(() -> BlogNotFoundException.EXCEPTION);
blogJpaRepository.deleteById(entity.getIdx());   // entity.getIdx() == idx
```
**after**:
```java
if (!blogJpaRepository.existsById(idx)) {
    throw BlogNotFoundException.EXCEPTION;
}
blogJpaRepository.deleteById(idx);
```
- `existsById`로 NotFound 체크는 유지하되 풀 row SELECT 제거
- `NewsService.delete`도 동일 패턴 적용

### 2. `GcpService.checkFileIsEmpty` / `checkFileType` 가시성
- 두 메서드 모두 같은 클래스의 `upload()`에서만 호출됨 (외부 노출 의도 없음)
- `public` → `private`으로 좁힘

### 3. `AuthService` 매직넘버 `180` 상수화
**before**:
```java
redisRepository.save(email, authcode, 180, TimeUnit.SECONDS);
```
**after**:
```java
private static final int AUTH_CODE_TTL_SECONDS = 180;
...
redisRepository.save(email, authcode, AUTH_CODE_TTL_SECONDS, TimeUnit.SECONDS);
```
- `RedisRepository.save` 시그니처가 `int timeout`이라 `int` 상수로 정의

## 전달할 추가 이슈
- 본 PR은 `AuthService.java`를 건드리므로, `fix/auth-query-service-split` (#106)와 동일 파일 충돌 가능. 머지 순서: 둘 중 먼저 머지된 후 다른 하나는 rebase 필요.