### PR TITLE
bug/jackson3-object-mapper-import

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
@@ -61,7 +61,9 @@ public class WebAuthnUseCase {
 
     // Yubico WebAuthn 라이브러리가 Jackson 2.x 기반이라 동일 버전을 직접 인스턴스화한다.
     // Spring Boot 4의 자동 설정 ObjectMapper는 Jackson 3 (tools.jackson) 빈이라 호환 안 됨.
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    // findAndRegisterModules()로 classpath에 있는 모듈(parameter-names, jsr310 등)을 자동 등록하여
+    // record 역직렬화와 Java 8 시간 타입 처리를 안전하게 지원한다.
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     private final RelyingParty relyingParty;
     private final AdminQueryService adminQueryService;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
@@ -59,6 +59,10 @@ public class WebAuthnUseCase {
     private static final int CHALLENGE_TTL_MINUTES = 5;
     private static final String ALLOWED_EMAIL_DOMAIN = "bigtablet.com";
 
+    // Yubico WebAuthn 라이브러리가 Jackson 2.x 기반이라 동일 버전을 직접 인스턴스화한다.
+    // Spring Boot 4의 자동 설정 ObjectMapper는 Jackson 3 (tools.jackson) 빈이라 호환 안 됨.
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     private final RelyingParty relyingParty;
     private final AdminQueryService adminQueryService;
     private final AdminService adminService;
@@ -67,7 +71,6 @@ public class WebAuthnUseCase {
     private final EmailVerificationQueryService emailVerificationQueryService;
     private final JwtTokenService jwtTokenService;
     private final RedisRepository redisRepository;
-    private final ObjectMapper objectMapper;
 
     /**
      * 물리키 등록 시작 — 챌린지 발급 + Redis 캐싱 (5분)


### PR DESCRIPTION
## 제목
bug/jackson3-object-mapper-import — `ObjectMapper` 빈 누락으로 인한 애플리케이션 부트 실패 수정

## 작업한 내용
PR #111 머지 후 develop 부트 시 다음 에러로 실패:

```
Parameter 8 of constructor in ...WebAuthnUseCase required a bean of type
'com.fasterxml.jackson.databind.ObjectMapper' that could not be found.
```

### 원인
Spring Boot 4의 자동 설정 `ObjectMapper`는 Jackson 3(`tools.jackson.databind.ObjectMapper`)이고, 우리 코드가 요청한 Jackson 2(`com.fasterxml.jackson.databind.ObjectMapper`) 타입의 빈은 자동 등록되지 않음.

classpath에는 두 Jackson 버전이 모두 존재:
- `tools.jackson:*` 3.1.2 — Spring Boot starter
- `com.fasterxml.jackson:*` 2.21.2 — **Yubico webauthn-server-core 2.5.3가 transitive로 가져옴**

Yubico의 JSON 유틸 (`toCredentialsCreateJson`, `toJson`, `toCredentialsGetJson`)이 `com.fasterxml.jackson.core.JsonProcessingException`(Jackson 2의 checked 예외)을 던지므로 우리도 Jackson 2를 그대로 사용하는 게 자연스러움.

### 수정
`WebAuthnUseCase`에서 생성자 주입 대신 **필드 직접 인스턴스화**로 변경:

```java
// Yubico가 Jackson 2 기반이라 동일 버전을 직접 인스턴스화. Spring Boot 4의
// 자동 설정 ObjectMapper는 Jackson 3 빈이라 호환 안 됨.
private final ObjectMapper objectMapper = new ObjectMapper();
```

기존 `try { ... } catch (JsonProcessingException e)` catch 블록은 그대로 유지 — Yubico가 같은 checked 예외 타입을 던지기 때문에 API drift 없음.

### 검증
- `./gradlew build -x test` 통과
- `WebAuthnUseCase` 생성자 파라미터에서 `ObjectMapper` 제거됨 → 부트 실패 원인 해소

## 전달할 추가 이슈
- 장기적으로 Yubico가 Jackson 3로 마이그레이션하거나, 우리 코드가 `tools.jackson` 기반의 모든 의존성을 사용하게 되면 `tools.jackson` 빈 주입으로 통일 가능. 현재는 Yubico 의존성 때문에 Jackson 2 사용이 필수.