### PR TITLE
fix/dedup-email-domain-validation

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
@@ -3,6 +3,7 @@ package com.bigtablet.bigtablethompageserver.domain.admin.application.query;
 import com.bigtablet.bigtablethompageserver.domain.admin.domain.model.Admin;
 import com.bigtablet.bigtablethompageserver.domain.admin.domain.repository.jpa.AdminJpaRepository;
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.AdminNotFoundException;
+import com.bigtablet.bigtablethompageserver.domain.admin.exception.InvalidEmailDomainException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminQueryService {
+
+    // 허용된 어드민 이메일 도메인 — bigtablet.com 정확 매치만 통과 (서브도메인 차단)
+    private static final String ALLOWED_EMAIL_DOMAIN = "bigtablet.com";
 
     private final AdminJpaRepository adminJpaRepository;
 
@@ -45,6 +49,18 @@ public class AdminQueryService {
         return adminJpaRepository.findById(id)
                 .map(Admin::of)
                 .orElseThrow(() -> AdminNotFoundException.EXCEPTION);
+    }
+
+    /**
+     * 어드민 이메일 도메인 검증 (서브도메인 차단, 정확 매치만 통과)
+     * @param email String 어드민 이메일
+     * @return void (도메인 불일치 시 예외)
+     */
+    public void checkEmailDomain(String email) {
+        String[] parts = email.split("@");
+        if (parts.length != 2 || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
+            throw InvalidEmailDomainException.EXCEPTION;
+        }
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
@@ -53,10 +53,13 @@ public class AdminQueryService {
 
     /**
      * 어드민 이메일 도메인 검증 (서브도메인 차단, 정확 매치만 통과)
-     * @param email String 어드민 이메일
+     * @param email String 어드민 이메일 (null 허용 — null이면 도메인 불일치 처리)
      * @return void (도메인 불일치 시 예외)
      */
     public void checkEmailDomain(String email) {
+        if (email == null) {
+            throw InvalidEmailDomainException.EXCEPTION;
+        }
         String[] parts = email.split("@");
         if (parts.length != 2 || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
             throw InvalidEmailDomainException.EXCEPTION;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
@@ -13,7 +13,6 @@ import com.bigtablet.bigtablethompageserver.domain.admin.client.dto.request.WebA
 import com.bigtablet.bigtablethompageserver.domain.admin.client.dto.request.WebAuthnRegisterStartRequest;
 import com.bigtablet.bigtablethompageserver.domain.admin.domain.model.Admin;
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.CredentialAlreadyRegisteredException;
-import com.bigtablet.bigtablethompageserver.domain.admin.exception.InvalidEmailDomainException;
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.WebAuthnAuthenticationFailedException;
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.WebAuthnRegistrationFailedException;
 import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
@@ -57,7 +56,6 @@ public class WebAuthnUseCase {
     private static final String WEBAUTHN_REG_KEY_PREFIX = "webauthn-reg:";
     private static final String WEBAUTHN_LOGIN_KEY_PREFIX = "webauthn-login:";
     private static final int CHALLENGE_TTL_MINUTES = 5;
-    private static final String ALLOWED_EMAIL_DOMAIN = "bigtablet.com";
 
     // Yubico WebAuthn 라이브러리가 Jackson 2.x 기반이라 동일 버전을 직접 인스턴스화한다.
     // Spring Boot 4의 자동 설정 ObjectMapper는 Jackson 3 (tools.jackson) 빈이라 호환 안 됨.
@@ -81,7 +79,7 @@ public class WebAuthnUseCase {
      */
     public WebAuthnOptionsResponse registerStart(WebAuthnRegisterStartRequest request) {
         log.info("[WebAuthnUseCase] registerStart - email={}", request.email());
-        validateEmailDomain(request.email());
+        adminQueryService.checkEmailDomain(request.email());
         emailVerificationQueryService.checkCertified(request.email());
         String adminId = findOrCreateAdmin(request.email());
         UserIdentity userIdentity = UserIdentity.builder()
@@ -169,7 +167,7 @@ public class WebAuthnUseCase {
      */
     public WebAuthnOptionsResponse loginStart(WebAuthnLoginStartRequest request) {
         log.info("[WebAuthnUseCase] loginStart - email={}", request.email());
-        validateEmailDomain(request.email());
+        adminQueryService.checkEmailDomain(request.email());
         Admin admin = adminQueryService.findByEmail(request.email());
         if (!webAuthnQueryService.hasCredential(admin.id())) {
             throw WebAuthnAuthenticationFailedException.EXCEPTION;
@@ -204,7 +202,7 @@ public class WebAuthnUseCase {
     @Transactional
     public JsonWebTokenResponse loginFinish(WebAuthnLoginFinishRequest request) {
         log.info("[WebAuthnUseCase] loginFinish - email={}", request.email());
-        validateEmailDomain(request.email());
+        adminQueryService.checkEmailDomain(request.email());
         Admin admin = adminQueryService.findByEmail(request.email());
         String redisKey = WEBAUTHN_LOGIN_KEY_PREFIX + admin.id();
         String assertionRequestJson = redisRepository.getByKey(redisKey, String.class);
@@ -234,14 +232,6 @@ public class WebAuthnUseCase {
         } catch (AssertionFailedException | IOException e) {
             log.error("[WebAuthnUseCase] loginFinish 실패 - email={}", request.email(), e);
             throw WebAuthnAuthenticationFailedException.EXCEPTION;
-        }
-    }
-
-    // 이메일 도메인 검증 (@bigtablet.com 도메인만 허용, 서브도메인 차단)
-    private void validateEmailDomain(String email) {
-        String[] parts = email.split("@");
-        if (parts.length != 2 || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
-            throw InvalidEmailDomainException.EXCEPTION;
         }
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/client/api/EmailVerificationApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/client/api/EmailVerificationApiHandler.java
@@ -1,9 +1,9 @@
 package com.bigtablet.bigtablethompageserver.domain.admin.client.api;
 
+import com.bigtablet.bigtablethompageserver.domain.admin.application.query.AdminQueryService;
 import com.bigtablet.bigtablethompageserver.domain.admin.application.service.EmailVerificationService;
 import com.bigtablet.bigtablethompageserver.domain.admin.client.dto.request.EmailSendRequest;
 import com.bigtablet.bigtablethompageserver.domain.admin.client.dto.request.EmailVerifyRequest;
-import com.bigtablet.bigtablethompageserver.domain.admin.exception.InvalidEmailDomainException;
 import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,8 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/admin/email-verification")
 public class EmailVerificationApiHandler {
 
-    private static final String ALLOWED_EMAIL_DOMAIN = "bigtablet.com";
-
+    private final AdminQueryService adminQueryService;
     private final EmailVerificationService emailVerificationService;
 
     /**
@@ -33,7 +32,7 @@ public class EmailVerificationApiHandler {
     @PostMapping("/send")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse send(@RequestBody @Valid final EmailSendRequest request) {
-        validateEmailDomain(request.email());
+        adminQueryService.checkEmailDomain(request.email());
         emailVerificationService.sendCode(request.email());
         return BaseResponse.ok("OTP 발송 성공");
     }
@@ -46,17 +45,9 @@ public class EmailVerificationApiHandler {
     @PostMapping("/verify")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse verify(@RequestBody @Valid final EmailVerifyRequest request) {
-        validateEmailDomain(request.email());
+        adminQueryService.checkEmailDomain(request.email());
         emailVerificationService.verifyCode(request.email(), request.code());
         return BaseResponse.ok("이메일 인증 성공");
-    }
-
-    // 이메일 도메인 정합성 검증 (@bigtablet.com만 허용, 서브도메인 차단)
-    private void validateEmailDomain(String email) {
-        String[] parts = email.split("@");
-        if (parts.length != 2 || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
-            throw InvalidEmailDomainException.EXCEPTION;
-        }
     }
 
 }


### PR DESCRIPTION
## 제목
fix/dedup-email-domain-validation — admin 이메일 도메인 검증 중복 제거

Closes #113

## 작업한 내용
admin 도메인의 두 entry point에 완전히 동일한 `validateEmailDomain` 로직이 중복 존재:
- `WebAuthnUseCase.java:241` — 3개 호출(registerStart, loginStart, loginFinish)
- `EmailVerificationApiHandler.java:55` — 2개 호출(send, verify)

→ `AdminQueryService`에 `checkEmailDomain(String email)` 추가, 두 곳 모두 위 단일 지점 사용.

### 변경
- **추가**: `AdminQueryService.checkEmailDomain(String email)` (컨벤션의 `check*` 패턴, QueryService 위치)
- **WebAuthnUseCase**: 로컬 `ALLOWED_EMAIL_DOMAIN` 상수 + private `validateEmailDomain` 메서드 + `InvalidEmailDomainException` import 제거. 3개 호출 사이트를 `adminQueryService.checkEmailDomain` 로 변경.
- **EmailVerificationApiHandler**: 동일 로직/상수 제거. `AdminQueryService` 주입 추가. 2개 호출 사이트 변경.

5개 호출 모두 동일 단일 지점 통과. 도메인 정책 변경 시 한 곳만 수정.

### 검증
- `./gradlew build -x test` 통과
- 동작 변경 없음 — 같은 `InvalidEmailDomainException` 그대로 throw

## 전달할 추가 이슈
- 본 PR은 `WebAuthnUseCase`를 건드리므로 #114(JwtTokenService 제거), #115(TTL config externalize)와 동일 파일 충돌. 머지 순서 조정 필요.
- 향후 도메인 화이트리스트가 늘어나면(예: `@bigtablet.io` 추가) `application.admin.allowedEmailDomains` config property로 외부화 검토 — 별도 티켓