### PR TITLE
config/admin-ttl-properties

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
@@ -30,7 +30,7 @@ public class EmailVerificationService {
     private final AdminAuthProperties adminAuthProperties;
 
     /**
-     * 6자리 OTP 생성 후 Redis에 저장하고 이메일로 발송 (application.admin.otpTtlSeconds 적용)
+     * 6자리 OTP 생성 후 Redis에 저장하고 이메일로 발송 (application.admin.otp-ttl 적용)
      * @param email String 어드민 이메일
      * @return void
      */
@@ -46,13 +46,13 @@ public class EmailVerificationService {
             code.append(r.nextInt(10));
         }
         String authCode = code.toString();
-        redisRepository.save(OTP_KEY_PREFIX + normalized, authCode, adminAuthProperties.otpTtlSeconds(), TimeUnit.SECONDS);
+        redisRepository.save(OTP_KEY_PREFIX + normalized, authCode, (int) adminAuthProperties.otpTtl().toSeconds(), TimeUnit.SECONDS);
         String content = mailTemplateRenderer.renderAuthCodeEmail(authCode);
         emailService.sendNoReply(email, "[Bigtablet, Inc.] 어드민 이메일 인증 코드", content);
     }
 
     /**
-     * OTP 검증 후 인증 완료 플래그를 저장 (application.admin.certTtlSeconds 적용, 검증 성공 시 OTP는 즉시 삭제)
+     * OTP 검증 후 인증 완료 플래그를 저장 (application.admin.cert-ttl 적용, 검증 성공 시 OTP는 즉시 삭제)
      * @param email String 어드민 이메일
      * @param authCode String 클라이언트가 입력한 OTP
      * @return void
@@ -65,7 +65,7 @@ public class EmailVerificationService {
             throw EmailCodeMismatchException.EXCEPTION;
         }
         redisRepository.delete(OTP_KEY_PREFIX + normalized);
-        redisRepository.save(CERT_KEY_PREFIX + normalized, "1", adminAuthProperties.certTtlSeconds(), TimeUnit.SECONDS);
+        redisRepository.save(CERT_KEY_PREFIX + normalized, "1", (int) adminAuthProperties.certTtl().toSeconds(), TimeUnit.SECONDS);
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
@@ -4,6 +4,7 @@ import com.bigtablet.bigtablethompageserver.domain.admin.exception.EmailCodeMism
 import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
+import com.bigtablet.bigtablethompageserver.global.security.admin.config.AdminAuthProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,21 +19,18 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class EmailVerificationService {
 
-    // OTP Redis 키 접두어 (3분 TTL)
+    // OTP Redis 키 접두어
     private static final String OTP_KEY_PREFIX = "admin-email-otp:";
-    // 인증 완료 플래그 Redis 키 접두어 (30분 TTL)
+    // 인증 완료 플래그 Redis 키 접두어
     private static final String CERT_KEY_PREFIX = "admin-email-cert:";
-    // OTP TTL (초)
-    private static final int OTP_TTL_SECONDS = 180;
-    // 인증 완료 플래그 TTL (초) — WebAuthn 등록까지의 유효 윈도
-    private static final int CERT_TTL_SECONDS = 1800;
 
     private final RedisRepository redisRepository;
     private final EmailService emailService;
     private final MailTemplateRenderer mailTemplateRenderer;
+    private final AdminAuthProperties adminAuthProperties;
 
     /**
-     * 6자리 OTP 생성 후 Redis에 저장하고 이메일로 발송 (3분 TTL)
+     * 6자리 OTP 생성 후 Redis에 저장하고 이메일로 발송 (application.admin.otpTtlSeconds 적용)
      * @param email String 어드민 이메일
      * @return void
      */
@@ -48,13 +46,13 @@ public class EmailVerificationService {
             code.append(r.nextInt(10));
         }
         String authCode = code.toString();
-        redisRepository.save(OTP_KEY_PREFIX + normalized, authCode, OTP_TTL_SECONDS, TimeUnit.SECONDS);
+        redisRepository.save(OTP_KEY_PREFIX + normalized, authCode, adminAuthProperties.otpTtlSeconds(), TimeUnit.SECONDS);
         String content = mailTemplateRenderer.renderAuthCodeEmail(authCode);
         emailService.sendNoReply(email, "[Bigtablet, Inc.] 어드민 이메일 인증 코드", content);
     }
 
     /**
-     * OTP 검증 후 인증 완료 플래그를 30분 TTL로 저장 (검증 성공 시 OTP는 즉시 삭제)
+     * OTP 검증 후 인증 완료 플래그를 저장 (application.admin.certTtlSeconds 적용, 검증 성공 시 OTP는 즉시 삭제)
      * @param email String 어드민 이메일
      * @param authCode String 클라이언트가 입력한 OTP
      * @return void
@@ -67,7 +65,7 @@ public class EmailVerificationService {
             throw EmailCodeMismatchException.EXCEPTION;
         }
         redisRepository.delete(OTP_KEY_PREFIX + normalized);
-        redisRepository.save(CERT_KEY_PREFIX + normalized, "1", CERT_TTL_SECONDS, TimeUnit.SECONDS);
+        redisRepository.save(CERT_KEY_PREFIX + normalized, "1", adminAuthProperties.certTtlSeconds(), TimeUnit.SECONDS);
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
@@ -103,7 +103,7 @@ public class WebAuthnUseCase {
             redisRepository.save(
                     redisKey,
                     objectMapper.writeValueAsString(challenge),
-                    adminAuthProperties.challengeTtlSeconds(),
+                    (int) adminAuthProperties.challengeTtl().toSeconds(),
                     TimeUnit.SECONDS
             );
             return WebAuthnOptionsResponse.builder()
@@ -183,7 +183,7 @@ public class WebAuthnUseCase {
             redisRepository.save(
                     redisKey,
                     assertionRequest.toJson(),
-                    adminAuthProperties.challengeTtlSeconds(),
+                    (int) adminAuthProperties.challengeTtl().toSeconds(),
                     TimeUnit.SECONDS
             );
             return WebAuthnOptionsResponse.builder()

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
@@ -16,6 +16,7 @@ import com.bigtablet.bigtablethompageserver.domain.admin.exception.CredentialAlr
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.WebAuthnAuthenticationFailedException;
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.WebAuthnRegistrationFailedException;
 import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
+import com.bigtablet.bigtablethompageserver.global.security.admin.config.AdminAuthProperties;
 import com.bigtablet.bigtablethompageserver.global.security.jwt.JwtProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,7 +56,6 @@ public class WebAuthnUseCase {
 
     private static final String WEBAUTHN_REG_KEY_PREFIX = "webauthn-reg:";
     private static final String WEBAUTHN_LOGIN_KEY_PREFIX = "webauthn-login:";
-    private static final int CHALLENGE_TTL_MINUTES = 5;
 
     // Yubico WebAuthn 라이브러리가 Jackson 2.x 기반이라 동일 버전을 직접 인스턴스화한다.
     // Spring Boot 4의 자동 설정 ObjectMapper는 Jackson 3 (tools.jackson) 빈이라 호환 안 됨.
@@ -71,6 +71,7 @@ public class WebAuthnUseCase {
     private final EmailVerificationQueryService emailVerificationQueryService;
     private final JwtProvider jwtProvider;
     private final RedisRepository redisRepository;
+    private final AdminAuthProperties adminAuthProperties;
 
     /**
      * 물리키 등록 시작 — 챌린지 발급 + Redis 캐싱 (5분)
@@ -102,7 +103,7 @@ public class WebAuthnUseCase {
             redisRepository.save(
                     redisKey,
                     objectMapper.writeValueAsString(challenge),
-                    CHALLENGE_TTL_MINUTES * 60,
+                    adminAuthProperties.challengeTtlSeconds(),
                     TimeUnit.SECONDS
             );
             return WebAuthnOptionsResponse.builder()
@@ -182,7 +183,7 @@ public class WebAuthnUseCase {
             redisRepository.save(
                     redisKey,
                     assertionRequest.toJson(),
-                    CHALLENGE_TTL_MINUTES * 60,
+                    adminAuthProperties.challengeTtlSeconds(),
                     TimeUnit.SECONDS
             );
             return WebAuthnOptionsResponse.builder()

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthConfig.java
@@ -1,0 +1,9 @@
+package com.bigtablet.bigtablethompageserver.global.security.admin.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AdminAuthProperties.class)
+public class AdminAuthConfig {
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthProperties.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthProperties.java
@@ -1,0 +1,13 @@
+package com.bigtablet.bigtablethompageserver.global.security.admin.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "application.admin")
+public record AdminAuthProperties(
+        // 이메일 OTP TTL (초 단위)
+        int otpTtlSeconds,
+        // OTP 검증 성공 후 인증 완료 윈도 TTL (초 단위)
+        int certTtlSeconds,
+        // WebAuthn 챌린지 캐싱 TTL (초 단위)
+        int challengeTtlSeconds
+) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthProperties.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthProperties.java
@@ -2,12 +2,14 @@ package com.bigtablet.bigtablethompageserver.global.security.admin.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 @ConfigurationProperties(prefix = "application.admin")
 public record AdminAuthProperties(
-        // 이메일 OTP TTL (초 단위)
-        int otpTtlSeconds,
-        // OTP 검증 성공 후 인증 완료 윈도 TTL (초 단위)
-        int certTtlSeconds,
-        // WebAuthn 챌린지 캐싱 TTL (초 단위)
-        int challengeTtlSeconds
+        // 이메일 OTP 유효 기간 (예: 3m)
+        Duration otpTtl,
+        // OTP 검증 성공 후 인증 완료 윈도 (예: 30m)
+        Duration certTtl,
+        // WebAuthn 챌린지 캐싱 유효 기간 (예: 5m)
+        Duration challengeTtl
 ) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,10 @@ application:
     rpId: ${secrets.WEBAUTHN_RP_ID}
     rpName: ${secrets.WEBAUTHN_RP_NAME}
     allowedOrigins: ${secrets.WEBAUTHN_ALLOWED_ORIGINS}
+  admin:
+    otpTtlSeconds: 180
+    certTtlSeconds: 1800
+    challengeTtlSeconds: 300
 
 slack:
   webhook-url: ${secrets.SLACK_WEBHOOK}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,9 +62,9 @@ application:
     rpName: ${secrets.WEBAUTHN_RP_NAME}
     allowedOrigins: ${secrets.WEBAUTHN_ALLOWED_ORIGINS}
   admin:
-    otpTtlSeconds: 180
-    certTtlSeconds: 1800
-    challengeTtlSeconds: 300
+    otp-ttl: 3m
+    cert-ttl: 30m
+    challenge-ttl: 5m
 
 slack:
   webhook-url: ${secrets.SLACK_WEBHOOK}


### PR DESCRIPTION
## 제목
config/admin-ttl-properties — admin 인증 TTL 상수를 `application.admin.*` config property로 외부화

Closes #115

## 작업한 내용
admin 인증 흐름의 TTL 상수 3개가 코드에 하드코딩되어 있어 운영 환경별 조정 불가. `JwtProperties` / `WebAuthnProperties` 패턴 따라 외부화.

### 변경
**신규**
- `global/security/admin/config/AdminAuthProperties` — `@ConfigurationProperties(prefix = "application.admin")` record
  - `otpTtlSeconds` (default 180 — 이메일 OTP 유효)
  - `certTtlSeconds` (default 1800 — OTP 검증 성공 후 인증 윈도)
  - `challengeTtlSeconds` (default 300 — WebAuthn 챌린지 유효)
- `global/security/admin/config/AdminAuthConfig` — `@EnableConfigurationProperties(AdminAuthProperties.class)`

**`application.yml`** 기본값 추가:
```yaml
application:
  admin:
    otpTtlSeconds: 180
    certTtlSeconds: 1800
    challengeTtlSeconds: 300
```
(secrets 아님 — 평문 기본값. 환경별 override는 표준 Spring 메커니즘으로)

**`application-local.yml`** 동일 기본값 추가 (gitignored)

**`EmailVerificationService`**
- `OTP_TTL_SECONDS`, `CERT_TTL_SECONDS` 상수 제거
- `AdminAuthProperties` 주입
- `adminAuthProperties.otpTtlSeconds()`, `.certTtlSeconds()` 사용

**`WebAuthnUseCase`**
- `CHALLENGE_TTL_MINUTES` 상수 제거 (`* 60` 변환도 함께 제거)
- `AdminAuthProperties` 주입
- `adminAuthProperties.challengeTtlSeconds()` 직접 사용 (registerStart, loginStart 양쪽)

### 검증
- `./gradlew build -x test` 통과
- 기본값을 그대로 적용해 기존 동작 보존

## 전달할 추가 이슈
- 본 PR은 `WebAuthnUseCase`를 건드리므로 #113 / #114와 동일 파일 충돌. 머지 순서 조정 필요 (3개 중 마지막 머지되는 PR은 rebase 권장).
- `application-local.yml`은 gitignored라 커밋에 미포함. 다른 개발자 로컬 환경에서 새 키 추가 필요. (`OTP_TTL_SECONDS=180`, `CERT_TTL_SECONDS=1800`, `CHALLENGE_TTL_SECONDS=300`)