### PR TITLE
fix: harden admin email validation and add Duration defaults

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
@@ -61,9 +61,9 @@ public class AdminQueryService {
             throw InvalidEmailDomainException.EXCEPTION;
         }
         // split("@", -1)로 트레일링 빈 토큰 보존 — "user@bigtablet.com@" 같은 비정상 입력 차단
-        // parts[0] 빈 체크 — "@bigtablet.com" 같이 로컬 파트 없는 입력 차단
+        // parts[0] blank 체크 — "@bigtablet.com" / " @bigtablet.com" 같이 로컬 파트가 비거나 공백뿐인 입력 차단
         String[] parts = email.split("@", -1);
-        if (parts.length != 2 || parts[0].isEmpty() || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
+        if (parts.length != 2 || parts[0].isBlank() || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
             throw InvalidEmailDomainException.EXCEPTION;
         }
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
@@ -60,8 +60,10 @@ public class AdminQueryService {
         if (email == null) {
             throw InvalidEmailDomainException.EXCEPTION;
         }
-        String[] parts = email.split("@");
-        if (parts.length != 2 || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
+        // split("@", -1)로 트레일링 빈 토큰 보존 — "user@bigtablet.com@" 같은 비정상 입력 차단
+        // parts[0] 빈 체크 — "@bigtablet.com" 같이 로컬 파트 없는 입력 차단
+        String[] parts = email.split("@", -1);
+        if (parts.length != 2 || parts[0].isEmpty() || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
             throw InvalidEmailDomainException.EXCEPTION;
         }
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthProperties.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthProperties.java
@@ -1,15 +1,17 @@
 package com.bigtablet.bigtablethompageserver.global.security.admin.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 
 import java.time.Duration;
 
+// application.yml 누락 시 NPE 방지를 위해 @DefaultValue로 안전 기본값 제공 — yml에 명시된 값과 동일하게 유지
 @ConfigurationProperties(prefix = "application.admin")
 public record AdminAuthProperties(
         // 이메일 OTP 유효 기간 (예: 3m)
-        Duration otpTtl,
+        @DefaultValue("3m") Duration otpTtl,
         // OTP 검증 성공 후 인증 완료 윈도 (예: 30m)
-        Duration certTtl,
+        @DefaultValue("30m") Duration certTtl,
         // WebAuthn 챌린지 캐싱 유효 기간 (예: 5m)
-        Duration challengeTtl
+        @DefaultValue("5m") Duration challengeTtl
 ) {}


### PR DESCRIPTION
## 제목
PR #119 Gemini 리뷰 반영 — admin 이메일 검증 엣지 케이스 차단 + `AdminAuthProperties` NPE 안전망

## 작업한 내용

### 1. `AdminQueryService.checkEmailDomain` 강화
- `split("@", -1)` 적용 — 트레일링 빈 토큰 보존
- `parts[0].isEmpty()` 가드 추가
- 차단되는 비정상 입력:
  - `user@bigtablet.com@` (트레일링 `@`)
  - `@bigtablet.com` (로컬 파트 없음)

```java
String[] parts = email.split("@", -1);
if (parts.length != 2 || parts[0].isEmpty() || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
    throw InvalidEmailDomainException.EXCEPTION;
}
```

### 2. `AdminAuthProperties` `@DefaultValue` 적용
- `application.yml` 누락 시 `Duration` 필드 `null` → 사용 시점 NPE 위험 제거
- yml 명시값과 동일한 안전 기본값 부여
  - `otpTtl = 3m`
  - `certTtl = 30m`
  - `challengeTtl = 5m`

## 전달할 추가 이슈
- Gemini 리뷰 #3 (`ALLOWED_EMAIL_DOMAIN` 외부화) → 스코프 미스매치로 분리, 이슈 #120 등록
- 이 PR이 develop에 머지되면 PR #119(develop→main)에 자동 반영됨