### PR TITLE
config: externalize admin allowed email domain to AdminAuthProperties

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
@@ -4,6 +4,7 @@ import com.bigtablet.bigtablethompageserver.domain.admin.domain.model.Admin;
 import com.bigtablet.bigtablethompageserver.domain.admin.domain.repository.jpa.AdminJpaRepository;
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.AdminNotFoundException;
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.InvalidEmailDomainException;
+import com.bigtablet.bigtablethompageserver.global.security.admin.config.AdminAuthProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,10 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AdminQueryService {
 
-    // 허용된 어드민 이메일 도메인 — bigtablet.com 정확 매치만 통과 (서브도메인 차단)
-    private static final String ALLOWED_EMAIL_DOMAIN = "bigtablet.com";
-
     private final AdminJpaRepository adminJpaRepository;
+    private final AdminAuthProperties adminAuthProperties;
 
     /**
      * 이메일로 어드민 조회
@@ -53,6 +52,7 @@ public class AdminQueryService {
 
     /**
      * 어드민 이메일 도메인 검증 (서브도메인 차단, 정확 매치만 통과)
+     * 허용 도메인은 application.admin.allowed-email-domain 프로퍼티로 외부화됨
      * @param email String 어드민 이메일 (null 허용 — null이면 도메인 불일치 처리)
      * @return void (도메인 불일치 시 예외)
      */
@@ -63,7 +63,7 @@ public class AdminQueryService {
         // split("@", -1)로 트레일링 빈 토큰 보존 — "user@bigtablet.com@" 같은 비정상 입력 차단
         // parts[0] blank 체크 — "@bigtablet.com" / " @bigtablet.com" 같이 로컬 파트가 비거나 공백뿐인 입력 차단
         String[] parts = email.split("@", -1);
-        if (parts.length != 2 || parts[0].isBlank() || !parts[1].equalsIgnoreCase(ALLOWED_EMAIL_DOMAIN)) {
+        if (parts.length != 2 || parts[0].isBlank() || !parts[1].equalsIgnoreCase(adminAuthProperties.allowedEmailDomain())) {
             throw InvalidEmailDomainException.EXCEPTION;
         }
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthProperties.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/admin/config/AdminAuthProperties.java
@@ -13,5 +13,7 @@ public record AdminAuthProperties(
         // OTP 검증 성공 후 인증 완료 윈도 (예: 30m)
         @DefaultValue("30m") Duration certTtl,
         // WebAuthn 챌린지 캐싱 유효 기간 (예: 5m)
-        @DefaultValue("5m") Duration challengeTtl
+        @DefaultValue("5m") Duration challengeTtl,
+        // 어드민 회원가입 허용 이메일 도메인 (정확 매치만 통과, 서브도메인 차단)
+        @DefaultValue("bigtablet.com") String allowedEmailDomain
 ) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,7 @@ application:
     otp-ttl: 3m
     cert-ttl: 30m
     challenge-ttl: 5m
+    allowed-email-domain: bigtablet.com
 
 slack:
   webhook-url: ${secrets.SLACK_WEBHOOK}


### PR DESCRIPTION
## 제목
어드민 허용 이메일 도메인 외부화 — `AdminQueryService.ALLOWED_EMAIL_DOMAIN` 하드코딩 제거

## 작업한 내용
PR #118에서 시작된 admin 설정 외부화 패턴에 도메인 상수도 정렬.

### 변경
- `AdminAuthProperties` — `String allowedEmailDomain` 필드 추가, `@DefaultValue("bigtablet.com")` 안전망
- `application.yml` — `application.admin.allowed-email-domain: bigtablet.com` 추가
- `AdminQueryService.checkEmailDomain` — 상수 대신 `adminAuthProperties.allowedEmailDomain()` 참조, 기존 정확 매치 검증 로직은 유지

### 효과
- 환경별(dev/stg/prod) 도메인 분리 가능
- `application.admin.*` 하위에 admin 인증 관련 설정 일원화 (TTL 3종 + 도메인 1종)

## 전달할 추가 이슈
- 의존 관계: PR #121(이메일 검증 강화 + Duration `@DefaultValue`)과 같은 파일을 만짐. 두 PR 모두 develop으로 머지될 예정이며, 머지 순서에 따라 한쪽이 rebase 필요. 충돌 시 — 본 PR이 두번째 머지가 될 경우 `AdminAuthProperties`의 import/`@DefaultValue` 적용 양식을 PR #121 결과에 맞춰 통합
- `WEBAUTHN_RP_ID` secret과 도메인 일치성(`admin.bigtablet.com` ↔ `bigtablet.com`) 확인 별도 운영 이슈

Closes #120