### PR TITLE
fix/job-scheduler-bulk-update

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/scheduler/JobScheduler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/scheduler/JobScheduler.java
@@ -20,15 +20,18 @@ public class JobScheduler {
 
 	/**
 	 * 마감일이 지난 채용 공고를 자동 비활성화하는 스케줄러 (매일 자정 실행).
-	 * entity hydration 없이 bulk UPDATE 단일 쿼리로 처리한다.
+	 * entity hydration 없이 bulk UPDATE 단일 쿼리로 처리하고,
+	 * `<=` 비교로 누락된 일자의 공고까지 안전하게 정리한다.
 	 */
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void deactivateEndedJobs() {
-		LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
-		int affected = jobJpaRepository.deactivateAllByEndDate(yesterday);
+		ZoneId seoul = ZoneId.of("Asia/Seoul");
+		LocalDate cutoff = LocalDate.now(seoul).minusDays(1);
+		LocalDateTime now = LocalDateTime.now(seoul);
+		int affected = jobJpaRepository.deactivateAllByEndDate(cutoff, now);
 		if (affected > 0) {
-			log.info("[JobScheduler] deactivateEndedJobs - count={}, time={}", affected, LocalDateTime.now());
+			log.info("[JobScheduler] deactivateEndedJobs - count={}, cutoff={}, time={}", affected, cutoff, now);
 		}
 	}
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/scheduler/JobScheduler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/scheduler/JobScheduler.java
@@ -1,6 +1,5 @@
 package com.bigtablet.bigtablethompageserver.domain.job.application.scheduler;
 
-import com.bigtablet.bigtablethompageserver.domain.job.domain.entity.JobEntity;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.repository.jpa.JobJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
 
 @Slf4j
 @Component
@@ -21,17 +19,16 @@ public class JobScheduler {
 	private final JobJpaRepository jobJpaRepository;
 
 	/**
-	 * 마감일이 지난 채용 공고를 자동 비활성화하는 스케줄러 (매일 자정 실행)
+	 * 마감일이 지난 채용 공고를 자동 비활성화하는 스케줄러 (매일 자정 실행).
+	 * entity hydration 없이 bulk UPDATE 단일 쿼리로 처리한다.
 	 */
 	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void deactivateEndedJobs() {
 		LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
-		List<JobEntity> jobsEnded = jobJpaRepository.findAllByIsActiveTrueAndEndDate(yesterday);
-		if (!jobsEnded.isEmpty()) {
-			jobsEnded.forEach(JobEntity::deactivate);
-			jobJpaRepository.saveAll(jobsEnded);
-			log.info("[JobScheduler] deactivateEndedJobs - count={}, time={}", jobsEnded.size(), LocalDateTime.now());
+		int affected = jobJpaRepository.deactivateAllByEndDate(yesterday);
+		if (affected > 0) {
+			log.info("[JobScheduler] deactivateEndedJobs - count={}, time={}", affected, LocalDateTime.now());
 		}
 	}
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/repository/jpa/JobJpaRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/repository/jpa/JobJpaRepository.java
@@ -5,6 +5,9 @@ import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Department;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Education;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -23,6 +26,14 @@ public interface JobJpaRepository extends JpaRepository<JobEntity, Long> {
 
     List<JobEntity> findAllByIsActiveFalseOrderByCreatedAtDesc();
 
-    List<JobEntity> findAllByIsActiveTrueAndEndDate(LocalDate endDate);
+    /**
+     * 지정된 마감일에 도래한 활성 채용 공고를 일괄 비활성화한다 (스케줄러용).
+     * entity hydration 없이 단일 UPDATE를 실행하므로 메모리/I/O 비용이 일정.
+     * @param endDate LocalDate 비활성화 대상 마감일
+     * @return int 영향받은 row 수
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE JobEntity j SET j.isActive = false WHERE j.endDate = :endDate AND j.isActive = true")
+    int deactivateAllByEndDate(@Param("endDate") LocalDate endDate);
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/repository/jpa/JobJpaRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/repository/jpa/JobJpaRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface JobJpaRepository extends JpaRepository<JobEntity, Long> {
@@ -27,13 +28,16 @@ public interface JobJpaRepository extends JpaRepository<JobEntity, Long> {
     List<JobEntity> findAllByIsActiveFalseOrderByCreatedAtDesc();
 
     /**
-     * 지정된 마감일에 도래한 활성 채용 공고를 일괄 비활성화한다 (스케줄러용).
-     * entity hydration 없이 단일 UPDATE를 실행하므로 메모리/I/O 비용이 일정.
-     * @param endDate LocalDate 비활성화 대상 마감일
+     * 지정된 기준일 이전(포함)에 마감된 활성 채용 공고를 일괄 비활성화한다 (스케줄러용).
+     * entity hydration 없이 단일 UPDATE를 실행하므로 메모리/I/O 비용이 일정하고,
+     * 스케줄러가 특정 일자에 실행되지 못해 누락된 데이터까지 다음 실행에서 처리된다.
+     * 벌크 UPDATE는 JPA Auditing을 우회하므로 modifiedAt을 쿼리에 명시한다.
+     * @param endDate LocalDate 비활성화 기준일 (해당 일 포함, 이전 데이터까지 처리)
+     * @param modifiedAt LocalDateTime 갱신 시각
      * @return int 영향받은 row 수
      */
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE JobEntity j SET j.isActive = false WHERE j.endDate = :endDate AND j.isActive = true")
-    int deactivateAllByEndDate(@Param("endDate") LocalDate endDate);
+    @Query("UPDATE JobEntity j SET j.isActive = false, j.modifiedAt = :modifiedAt WHERE j.endDate <= :endDate AND j.isActive = true")
+    int deactivateAllByEndDate(@Param("endDate") LocalDate endDate, @Param("modifiedAt") LocalDateTime modifiedAt);
 
 }


### PR DESCRIPTION
## 제목
fix/job-scheduler-bulk-update — 마감 공고 비활성화 스케줄러를 bulk UPDATE로 전환

Closes #127

## 작업한 내용
- `JobJpaRepository`에 `@Modifying @Query` 기반 bulk update 추가:
  ```java
  @Modifying(clearAutomatically = true)
  @Query("UPDATE JobEntity j SET j.isActive = false
          WHERE j.endDate = :endDate AND j.isActive = true")
  int deactivateAllByEndDate(@Param("endDate") LocalDate endDate);
  ```
- `JobScheduler.deactivateEndedJobs`에서 위 메서드 호출로 치환 (entity 로드 → 메서드 호출 → saveAll 전부 제거)
- 사용 안 하는 `findAllByIsActiveTrueAndEndDate(LocalDate)` 파생 쿼리 제거 (다른 caller 없음)
- `clearAutomatically = true`로 영속성 컨텍스트 정합성 유지 (현재 caller인 스케줄러는 세션을 공유 안 하지만, 향후 다른 caller가 추가될 때 stale entity 노출 방지)

### 효과
- 하루에 마감 공고가 N건이든 SELECT + 메모리 보유 + N개 UPDATE → **UPDATE 1건**으로 축소
- 메모리 사용량/SQL 라운드트립 모두 O(1)
- 로그도 `affected` row 수만 받아 출력

## 전달할 추가 이슈
- 없음