### PR TITLE
refactor/mail-subject-constants

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/constant/RecruitMailSubject.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/constant/RecruitMailSubject.java
@@ -1,4 +1,4 @@
-package com.bigtablet.bigtablethompageserver.global.infra.email.subject;
+package com.bigtablet.bigtablethompageserver.domain.recruit.application.constant;
 
 public final class RecruitMailSubject {
 
@@ -23,7 +23,7 @@ public final class RecruitMailSubject {
      * @return String 이메일 제목
      */
     public static String applyConfirmed(String name) {
-        return PREFIX + " " + name + "님, 지원 접수 완료 안내드립니다";
+        return personalized(name, "지원 접수 완료 안내드립니다");
     }
 
     /**
@@ -32,7 +32,7 @@ public final class RecruitMailSubject {
      * @return String 이메일 제목
      */
     public static String interviewGuide(String name) {
-        return PREFIX + " " + name + "님, 면접 전형 안내드립니다";
+        return personalized(name, "면접 전형 안내드립니다");
     }
 
     /**
@@ -41,7 +41,17 @@ public final class RecruitMailSubject {
      * @return String 이메일 제목
      */
     public static String finalResult(String name) {
-        return PREFIX + " " + name + "님, 채용 전형 최종 결과 안내드립니다";
+        return personalized(name, "채용 전형 최종 결과 안내드립니다");
+    }
+
+    /**
+     * 공통 포맷: `{PREFIX} {name}님, {message}` — 호칭/구분자 변경 시 이 메서드만 수정.
+     * @param name String 수신자 이름
+     * @param message String 안내 메시지 본문
+     * @return String 조립된 이메일 제목
+     */
+    private static String personalized(String name, String message) {
+        return PREFIX + " " + name + "님, " + message;
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -2,6 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.recruit.application.usecase;
 
 import com.bigtablet.bigtablethompageserver.domain.job.application.query.JobQueryService;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.model.Job;
+import com.bigtablet.bigtablethompageserver.domain.recruit.application.constant.RecruitMailSubject;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.query.RecruitQueryService;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.response.RecruitResponse;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.service.RecruitService;
@@ -11,7 +12,6 @@ import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Status;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.Recruit;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
-import com.bigtablet.bigtablethompageserver.global.infra.email.subject.RecruitMailSubject;
 import com.bigtablet.bigtablethompageserver.global.infra.slack.service.SlackNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -11,6 +11,7 @@ import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Status;
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.model.Recruit;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
+import com.bigtablet.bigtablethompageserver.global.infra.email.subject.RecruitMailSubject;
 import com.bigtablet.bigtablethompageserver.global.infra.slack.service.SlackNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +46,7 @@ public class RecruitUseCase {
         String content = mailTemplateRenderer.renderApplyConfirmEmail(request.name(), job.title(), LocalDateTime.now());
         emailService.sendRecruit(
                 request.email(),
-                "[Bigtablet, Inc. 채용] " + request.name() + "님, 지원 접수 완료 안내드립니다",
+                RecruitMailSubject.applyConfirmed(request.name()),
                 content
         );
         try {
@@ -103,7 +104,7 @@ public class RecruitUseCase {
         recruitService.editStatus(status, idx);
         emailService.sendRecruit(
                 recruit.email(),
-                "[Bigtablet, Inc. 채용] " + recruit.name() + "님, 면접 전형 안내드립니다",
+                RecruitMailSubject.interviewGuide(recruit.name()),
                 content
         );
     }
@@ -122,7 +123,7 @@ public class RecruitUseCase {
         recruitService.accept(recruit.idx());
         emailService.sendRecruit(
                 recruit.email(),
-                "[Bigtablet, Inc. 채용] " + recruit.name() + "님, 채용 전형 최종 결과 안내드립니다",
+                RecruitMailSubject.finalResult(recruit.name()),
                 content
         );
     }
@@ -140,7 +141,7 @@ public class RecruitUseCase {
         recruitService.reject(recruit.idx());
         emailService.sendRecruit(
                 recruit.email(),
-                "[Bigtablet, Inc. 채용] " + recruit.name() + "님, 채용 전형 최종 결과 안내드립니다",
+                RecruitMailSubject.finalResult(recruit.name()),
                 content
         );
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.domain.talent.application.usecase;
 
+import com.bigtablet.bigtablethompageserver.domain.recruit.application.constant.RecruitMailSubject;
 import com.bigtablet.bigtablethompageserver.domain.talent.application.query.TalentQueryService;
 import com.bigtablet.bigtablethompageserver.domain.talent.application.response.TalentResponse;
 import com.bigtablet.bigtablethompageserver.domain.talent.application.service.TalentService;
@@ -12,7 +13,6 @@ import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentIsEmpt
 import com.bigtablet.bigtablethompageserver.global.common.util.CollectionValidator;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
-import com.bigtablet.bigtablethompageserver.global.infra.email.subject.RecruitMailSubject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
@@ -12,6 +12,7 @@ import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentIsEmpt
 import com.bigtablet.bigtablethompageserver.global.common.util.CollectionValidator;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
+import com.bigtablet.bigtablethompageserver.global.infra.email.subject.RecruitMailSubject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -45,7 +46,7 @@ public class TalentUseCase {
                 request.etcUrl()
         );
         String content = mailTemplateRenderer.renderTalentEmail(request.name(), LocalDateTime.now());
-        emailService.sendRecruit(request.email(), "[Bigtablet, Inc. 채용]", content);
+        emailService.sendRecruit(request.email(), RecruitMailSubject.brand(), content);
     }
 
     /**
@@ -58,7 +59,7 @@ public class TalentUseCase {
         Talent talent = talentQueryService.find(request.idx());
         talentService.editActive(talent.idx(), false);
         String content = mailTemplateRenderer.renderOfferEmail(talent.name(), request.text());
-        emailService.sendRecruit(talent.email(), "[Bigtablet, Inc. 채용]", content);
+        emailService.sendRecruit(talent.email(), RecruitMailSubject.brand(), content);
     }
 
     /**

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/email/subject/RecruitMailSubject.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/email/subject/RecruitMailSubject.java
@@ -1,0 +1,47 @@
+package com.bigtablet.bigtablethompageserver.global.infra.email.subject;
+
+public final class RecruitMailSubject {
+
+    private static final String PREFIX = "[Bigtablet, Inc. 채용]";
+
+    private RecruitMailSubject() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * 채용 도메인 이메일에 공통으로 붙는 브랜드 prefix.
+     * 본문 없이 prefix만 필요한 경우(예: 인재풀 등록 안내)에 사용한다.
+     * @return String 브랜드 prefix
+     */
+    public static String brand() {
+        return PREFIX;
+    }
+
+    /**
+     * 지원 접수 완료 안내 이메일 제목
+     * @param name String 지원자 이름
+     * @return String 이메일 제목
+     */
+    public static String applyConfirmed(String name) {
+        return PREFIX + " " + name + "님, 지원 접수 완료 안내드립니다";
+    }
+
+    /**
+     * 면접 전형 안내 이메일 제목
+     * @param name String 지원자 이름
+     * @return String 이메일 제목
+     */
+    public static String interviewGuide(String name) {
+        return PREFIX + " " + name + "님, 면접 전형 안내드립니다";
+    }
+
+    /**
+     * 채용 전형 최종 결과(합격/불합격 공통) 안내 이메일 제목
+     * @param name String 지원자 이름
+     * @return String 이메일 제목
+     */
+    public static String finalResult(String name) {
+        return PREFIX + " " + name + "님, 채용 전형 최종 결과 안내드립니다";
+    }
+
+}


### PR DESCRIPTION
## 제목
refactor/mail-subject-constants — 채용 이메일 제목 문자열을 `RecruitMailSubject`로 추출

Closes #128

## 작업한 내용
`[Bigtablet, Inc. 채용]` 브랜드 prefix와 4종 제목 문자열이 `RecruitUseCase`/`TalentUseCase`에 6번 중복돼 있던 상태. 브랜드/카피 변경 시 모든 호출 지점을 수정해야 했고, 4개 제목의 차이는 grep해야만 파악 가능.

### 신규
- `global/infra/email/subject/RecruitMailSubject` 유틸리티 클래스 (private 생성자):
  - `brand()` — prefix만 (`"[Bigtablet, Inc. 채용]"`) — 인재풀 등록 안내 등 본문 없는 케이스용
  - `applyConfirmed(name)` — 지원 접수 완료
  - `interviewGuide(name)` — 면접 전형 안내
  - `finalResult(name)` — 채용 전형 최종 결과 (합격/불합격 공통)

### 치환 (총 6곳)
| 파일:라인 | 변경 |
|---|---|
| `RecruitUseCase.java:48` | `applyConfirmed(request.name())` |
| `RecruitUseCase.java:106` | `interviewGuide(recruit.name())` |
| `RecruitUseCase.java:125, 143` | `finalResult(recruit.name())` |
| `TalentUseCase.java:48, 61` | `brand()` |

`acceptRecruit` / `rejectRecruit`는 기존 코드도 같은 제목 문자열을 쓰고 있어 `finalResult()`로 공통화. 동작 변경 없음.

## 전달할 추가 이슈
- `EmailVerificationService.java:51`의 `"[Bigtablet, Inc.] 어드민 이메일 인증 코드"`는 다른 prefix(채용 X)를 쓰고 admin 도메인 전용이라 본 PR scope에서 제외. 필요 시 `AdminMailSubject` 별도 도입 검토.
- `MailTemplateRenderer`의 7개 render 메서드를 단일 `render(MailTemplate, vars)` 시그니처로 통합하는 것도 가능하나 명시적 메서드가 type-safe라 trade-off가 있음 — 별도 티켓.