### PR TITLE
fix/slack-resttemplate-bean

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/config/web/RestTemplateConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/config/web/RestTemplateConfig.java
@@ -14,12 +14,13 @@ public class RestTemplateConfig {
     private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
 
     /**
-     * Slack/외부 HTTP 호출용 공용 RestTemplate.
+     * Slack webhook 호출용 RestTemplate.
      * connect/read timeout을 명시하여 외부 API 지연 시 호출 스레드(@Async 포함)가 무한 대기하지 않도록 한다.
+     * Bean 이름을 용도별로 스코프(`slackRestTemplate`)해 향후 다른 RestTemplate 추가 시 주입 충돌을 회피.
      * @return RestTemplate 타임아웃 적용된 RestTemplate
      */
     @Bean
-    public RestTemplate restTemplate() {
+    public RestTemplate slackRestTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(CONNECT_TIMEOUT);
         factory.setReadTimeout(READ_TIMEOUT);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/config/web/RestTemplateConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/config/web/RestTemplateConfig.java
@@ -1,0 +1,29 @@
+package com.bigtablet.bigtablethompageserver.global.config.web;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
+
+    /**
+     * Slack/외부 HTTP 호출용 공용 RestTemplate.
+     * connect/read timeout을 명시하여 외부 API 지연 시 호출 스레드(@Async 포함)가 무한 대기하지 않도록 한다.
+     * @return RestTemplate 타임아웃 적용된 RestTemplate
+     */
+    @Bean
+    public RestTemplate restTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT);
+        factory.setReadTimeout(READ_TIMEOUT);
+        return new RestTemplate(factory);
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
@@ -18,7 +18,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class SlackNotifier {
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
     @Value("${slack.webhook-url}")
     private String webhookUrl;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
@@ -18,7 +18,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class SlackNotifier {
 
-    private final RestTemplate restTemplate;
+    private final RestTemplate slackRestTemplate;
 
     @Value("${slack.webhook-url}")
     private String webhookUrl;
@@ -62,7 +62,7 @@ public class SlackNotifier {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
-        restTemplate.postForEntity(webhookUrl, entity, String.class);
+        slackRestTemplate.postForEntity(webhookUrl, entity, String.class);
     }
 
 }


### PR DESCRIPTION
## 제목
fix/slack-resttemplate-bean — `SlackNotifier`의 인라인 `RestTemplate`을 Bean으로 전환

Closes #133

## 작업한 내용
`SlackNotifier`가 `new RestTemplate()`을 직접 호출해 컨테이너 밖에서 인스턴스 생성하던 문제 정리:

```diff
- private final RestTemplate restTemplate = new RestTemplate();
+ private final RestTemplate restTemplate;  // @RequiredArgsConstructor로 주입
```

신규 `RestTemplateConfig` 추가:
- `connect timeout = 3s`, `read timeout = 5s` 명시
- `SimpleClientHttpRequestFactory.setConnectTimeout(Duration)` API 사용 — `spring-web` 코어에 있는 안정적인 API라 Spring Boot 4의 boot-web 패키지 재편 영향 없음

### 효과
- HTTP connection 재사용 가능 (Spring 표준 인프라 흐름)
- Slack 응답 지연 시 `@Async` 스레드 무한 대기 차단 (5초 read timeout)
- 향후 인터셉터/로깅 추가 시 한 곳에 적용

## 전달할 추가 이슈
- 외부 HTTP 호출이 더 늘어나면 `WebClient`로 통일 검토 가능 (별도 티켓)
- 빈 이름이 `restTemplate` 단일 — 향후 도메인별 분리 필요하면 `@Qualifier`로 확장