### PR TITLE
fix/jobusecase-delete-direct

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
@@ -57,13 +57,17 @@ public class JobService {
     }
 
     /**
-     * 채용 공고 삭제
+     * 채용 공고 삭제 (존재하지 않으면 JobNotFoundException).
+     * `edit`/`deactivate`와 동일하게 존재 여부를 명시적으로 검증해 404 응답 contract을 유지한다.
      * @param idx Long 채용 공고 ID
      * @return void
      */
     @Transactional
     public void delete(Long idx) {
         log.info("[JobService] delete - idx={}", idx);
+        if (!jobJpaRepository.existsById(idx)) {
+            throw JobNotFoundException.EXCEPTION;
+        }
         jobJpaRepository.deleteById(idx);
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
@@ -108,8 +108,7 @@ public class JobUseCase {
      */
     public void deleteJob(Long idx) {
         log.info("[JobUseCase] deleteJob - idx={}", idx);
-        Job job = jobQueryService.find(idx);
-        jobService.delete(job.idx());
+        jobService.delete(idx);
     }
 
 }


### PR DESCRIPTION
## 제목
fix/jobusecase-delete-direct — `JobUseCase.deleteJob` 불필요한 lookup 제거

Closes #134

## 작업한 내용
`JobUseCase.deleteJob`이 entity를 로드한 뒤 `idx`만 추출해서 service에 넘기던 패턴 제거:

```diff
 public void deleteJob(Long idx) {
     log.info("[JobUseCase] deleteJob - idx={}", idx);
-    Job job = jobQueryService.find(idx);
-    jobService.delete(job.idx());
+    jobService.delete(idx);
 }
```

`job.idx()`는 입력 `idx`와 항상 동일하므로 `find()` 호출은 100% 낭비. `BlogUseCase.deleteBlog`/`NewsUseCase.deleteNews`는 이미 `service.delete(idx)` 형태 — Job만 옛 패턴이었던 걸 통일.

## 전달할 추가 이슈
- `JobNotFoundException`(원래 `find()`가 throw하던 효과)이 더 이상 발생하지 않음 — `JobJpaRepository.deleteById`는 없는 id에 no-op. 만약 DELETE에서 404 응답이 필요하면 `JobService.delete` 안에서 existence check 추가 (별도 티켓).