### PR TITLE
style/javadoc

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/AdminQueryService.java
@@ -19,7 +19,7 @@ public class AdminQueryService {
 
     /**
      * 이메일로 어드민 조회
-     * @param email String 어드민 이메일
+     * @param email 어드민 이메일
      * @return Admin 어드민 도메인 객체
      */
     public Admin findByEmail(String email) {
@@ -30,7 +30,7 @@ public class AdminQueryService {
 
     /**
      * 이메일로 어드민 조회 (없으면 null 반환 — 동시성 안전한 신규 생성 분기용)
-     * @param email String 어드민 이메일
+     * @param email 어드민 이메일
      * @return Admin or null
      */
     public Admin findByEmailOrNull(String email) {
@@ -41,7 +41,7 @@ public class AdminQueryService {
 
     /**
      * ID로 어드민 조회
-     * @param id String 어드민 ID
+     * @param id 어드민 ID
      * @return Admin 어드민 도메인 객체
      */
     public Admin find(String id) {
@@ -53,8 +53,7 @@ public class AdminQueryService {
     /**
      * 어드민 이메일 도메인 검증 (서브도메인 차단, 정확 매치만 통과)
      * 허용 도메인은 application.admin.allowed-email-domain 프로퍼티로 외부화됨
-     * @param email String 어드민 이메일 (null 허용 — null이면 도메인 불일치 처리)
-     * @return void (도메인 불일치 시 예외)
+     * @param email 어드민 이메일 (null 허용 — null이면 도메인 불일치 처리)
      */
     public void checkEmailDomain(String email) {
         if (email == null) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/EmailVerificationQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/EmailVerificationQueryService.java
@@ -18,8 +18,7 @@ public class EmailVerificationQueryService {
 
     /**
      * 해당 이메일이 OTP 검증을 통과했는지 확인 (Redis 인증 완료 플래그 존재 여부)
-     * @param email String 어드민 이메일
-     * @return void (검증 실패 시 예외)
+     * @param email 어드민 이메일
      */
     public void checkCertified(String email) {
         String flag = redisRepository.getByKey(CERT_KEY_PREFIX + email.toLowerCase(), String.class);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/WebAuthnQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/query/WebAuthnQueryService.java
@@ -14,7 +14,7 @@ public class WebAuthnQueryService {
 
     /**
      * 어드민에게 등록된 크레덴셜 존재 여부 확인
-     * @param adminId String 어드민 ID
+     * @param adminId 어드민 ID
      * @return boolean 존재 시 true
      */
     public boolean hasCredential(String adminId) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/AdminService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/AdminService.java
@@ -19,7 +19,7 @@ public class AdminService {
 
     /**
      * 신규 어드민 저장 (UUID 자동 생성, 권한은 ADMIN 고정)
-     * @param email String 어드민 이메일
+     * @param email 어드민 이메일
      * @return String 생성된 어드민 ID
      */
     @Transactional

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
@@ -31,8 +31,7 @@ public class EmailVerificationService {
 
     /**
      * 6자리 OTP 생성 후 Redis에 저장하고 이메일로 발송 (application.admin.otp-ttl 적용)
-     * @param email String 어드민 이메일
-     * @return void
+     * @param email 어드민 이메일
      */
     public void sendCode(String email) {
         log.info("[EmailVerificationService] sendCode - email={}", email);
@@ -53,9 +52,8 @@ public class EmailVerificationService {
 
     /**
      * OTP 검증 후 인증 완료 플래그를 저장 (application.admin.cert-ttl 적용, 검증 성공 시 OTP는 즉시 삭제)
-     * @param email String 어드민 이메일
-     * @param authCode String 클라이언트가 입력한 OTP
-     * @return void
+     * @param email 어드민 이메일
+     * @param authCode 클라이언트가 입력한 OTP
      */
     public void verifyCode(String email, String authCode) {
         log.info("[EmailVerificationService] verifyCode - email={}", email);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/WebAuthnService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/WebAuthnService.java
@@ -17,12 +17,11 @@ public class WebAuthnService {
 
     /**
      * WebAuthn 크레덴셜 저장
-     * @param adminId String 어드민 ID
-     * @param credentialId String Credential ID (Base64URL)
-     * @param publicKeyCose String 공개키 (Base64)
-     * @param signatureCount long 서명 카운터
-     * @param keyName String 키 이름
-     * @return void
+     * @param adminId 어드민 ID
+     * @param credentialId Credential ID (Base64URL)
+     * @param publicKeyCose 공개키 (Base64)
+     * @param signatureCount 서명 카운터
+     * @param keyName 키 이름
      */
     @Transactional
     public void save(
@@ -44,9 +43,8 @@ public class WebAuthnService {
 
     /**
      * 서명 카운터 수정 (replay 방지)
-     * @param credentialId String Credential ID (Base64URL)
-     * @param signatureCount long 새 서명 카운터
-     * @return void
+     * @param credentialId Credential ID (Base64URL)
+     * @param signatureCount 새 서명 카운터
      */
     @Transactional
     public void editSignatureCount(String credentialId, long signatureCount) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
@@ -75,7 +75,7 @@ public class WebAuthnUseCase {
 
     /**
      * 물리키 등록 시작 — 챌린지 발급 + Redis 캐싱 (5분)
-     * @param request WebAuthnRegisterStartRequest 등록 시작 요청
+     * @param request 등록 시작 요청
      * @return WebAuthnOptionsResponse 등록 옵션 JSON
      */
     public WebAuthnOptionsResponse registerStart(WebAuthnRegisterStartRequest request) {
@@ -117,8 +117,7 @@ public class WebAuthnUseCase {
 
     /**
      * 물리키 등록 완료 — 크레덴셜 검증 후 저장
-     * @param request WebAuthnRegisterFinishRequest 등록 완료 요청
-     * @return void
+     * @param request 등록 완료 요청
      */
     @Transactional
     public void registerFinish(WebAuthnRegisterFinishRequest request) {
@@ -163,7 +162,7 @@ public class WebAuthnUseCase {
 
     /**
      * 물리키 로그인 시작 — 챌린지 발급 + Redis 캐싱 (5분)
-     * @param request WebAuthnLoginStartRequest 로그인 시작 요청
+     * @param request 로그인 시작 요청
      * @return WebAuthnOptionsResponse 로그인 옵션 JSON
      */
     public WebAuthnOptionsResponse loginStart(WebAuthnLoginStartRequest request) {
@@ -197,7 +196,7 @@ public class WebAuthnUseCase {
 
     /**
      * 물리키 로그인 완료 — 어설션 검증 후 JWT 발급
-     * @param request WebAuthnLoginFinishRequest 로그인 완료 요청
+     * @param request 로그인 완료 요청
      * @return JsonWebTokenResponse JWT (access + refresh)
      */
     @Transactional

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/client/api/EmailVerificationApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/client/api/EmailVerificationApiHandler.java
@@ -26,7 +26,7 @@ public class EmailVerificationApiHandler {
 
     /**
      * 어드민 이메일에 OTP 발송 API (3분 TTL)
-     * @param request EmailSendRequest 이메일 발송 요청
+     * @param request 이메일 발송 요청
      * @return BaseResponse 발송 완료 응답
      */
     @PostMapping("/send")
@@ -39,7 +39,7 @@ public class EmailVerificationApiHandler {
 
     /**
      * OTP 검증 후 인증 완료 플래그 발행 API (30분 TTL)
-     * @param request EmailVerifyRequest 인증 코드 검증 요청
+     * @param request 인증 코드 검증 요청
      * @return BaseResponse 검증 완료 응답
      */
     @PostMapping("/verify")

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/client/api/WebAuthnApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/client/api/WebAuthnApiHandler.java
@@ -29,7 +29,7 @@ public class WebAuthnApiHandler {
 
     /**
      * 물리키 등록 시작 API — 챌린지 발급
-     * @param request WebAuthnRegisterStartRequest 등록 시작 요청
+     * @param request 등록 시작 요청
      * @return BaseResponseData 등록 옵션 JSON
      */
     @PostMapping("/register/start")
@@ -45,7 +45,7 @@ public class WebAuthnApiHandler {
 
     /**
      * 물리키 등록 완료 API — 크레덴셜 저장
-     * @param request WebAuthnRegisterFinishRequest 등록 완료 요청
+     * @param request 등록 완료 요청
      * @return BaseResponse 등록 완료 응답
      */
     @PostMapping("/register/finish")
@@ -59,7 +59,7 @@ public class WebAuthnApiHandler {
 
     /**
      * 물리키 로그인 시작 API — 챌린지 발급
-     * @param request WebAuthnLoginStartRequest 로그인 시작 요청
+     * @param request 로그인 시작 요청
      * @return BaseResponseData 로그인 옵션 JSON
      */
     @PostMapping("/login/start")
@@ -75,7 +75,7 @@ public class WebAuthnApiHandler {
 
     /**
      * 물리키 로그인 완료 API — JWT 발급
-     * @param request WebAuthnLoginFinishRequest 로그인 완료 요청
+     * @param request 로그인 완료 요청
      * @return BaseResponseData JWT 토큰 응답
      */
     @PostMapping("/login/finish")

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/query/BlogQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/query/BlogQueryService.java
@@ -21,7 +21,7 @@ public class BlogQueryService {
 
     /**
      * ID로 블로그 조회
-     * @param idx Long 블로그 ID
+     * @param idx 블로그 ID
      * @return Blog 블로그 도메인 객체
      */
     public Blog find(Long idx) {
@@ -33,8 +33,8 @@ public class BlogQueryService {
 
     /**
      * 블로그 목록 페이지 조회
-     * @param page int 페이지 번호
-     * @param size int 페이지 크기
+     * @param page 페이지 번호
+     * @param size 페이지 크기
      * @return List<Blog> 블로그 도메인 객체 목록
      */
     public List<Blog> findAll(int page, int size) {
@@ -43,9 +43,9 @@ public class BlogQueryService {
 
     /**
      * 제목으로 블로그 검색
-     * @param page int 페이지 번호
-     * @param size int 페이지 크기
-     * @param title String 검색할 블로그 제목
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param title 검색할 블로그 제목
      * @return List<Blog> 블로그 도메인 객체 목록
      */
     public List<Blog> findAllByTitle(int page, int size, String title) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/response/BlogResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/response/BlogResponse.java
@@ -19,7 +19,7 @@ public record BlogResponse(
 ) {
     /**
      * Blog 도메인 객체를 BlogResponse로 변환합니다.
-     * @param blog Blog 변환할 도메인 객체
+     * @param blog 변환할 도메인 객체
      * @return BlogResponse 변환된 응답 DTO
      */
     public static BlogResponse of(Blog blog) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
@@ -17,12 +17,11 @@ public class BlogService {
 
     /**
      * 블로그 저장
-     * @param titleKr String 한국어 제목
-     * @param titleEn String 영어 제목
-     * @param contentKr String 한국어 내용
-     * @param contentEn String 영어 내용
-     * @param imageUrl String 이미지 URL
-     * @return void
+     * @param titleKr 한국어 제목
+     * @param titleEn 영어 제목
+     * @param contentKr 한국어 내용
+     * @param contentEn 영어 내용
+     * @param imageUrl 이미지 URL
      */
     @Transactional
     public void save(String titleKr, String titleEn, String contentKr, String contentEn, String imageUrl) {
@@ -39,13 +38,12 @@ public class BlogService {
 
     /**
      * 블로그 수정
-     * @param idx Long 블로그 ID
-     * @param titleKr String 한국어 제목
-     * @param titleEn String 영어 제목
-     * @param contentKr String 한국어 내용
-     * @param contentEn String 영어 내용
-     * @param imageUrl String 이미지 URL
-     * @return void
+     * @param idx 블로그 ID
+     * @param titleKr 한국어 제목
+     * @param titleEn 영어 제목
+     * @param contentKr 한국어 내용
+     * @param contentEn 영어 내용
+     * @param imageUrl 이미지 URL
      */
     @Transactional
     public void edit(Long idx, String titleKr, String titleEn, String contentKr, String contentEn, String imageUrl) {
@@ -56,8 +54,7 @@ public class BlogService {
 
     /**
      * 블로그 조회수 증가
-     * @param idx Long 블로그 ID
-     * @return void
+     * @param idx 블로그 ID
      */
     @Transactional
     public void addViews(Long idx) {
@@ -68,8 +65,7 @@ public class BlogService {
 
     /**
      * 블로그 삭제
-     * @param idx Long 블로그 ID
-     * @return void
+     * @param idx 블로그 ID
      */
     @Transactional
     public void delete(Long idx) {
@@ -82,7 +78,7 @@ public class BlogService {
 
     /**
      * ID로 BlogEntity 조회 (비관적 락)
-     * @param idx Long 블로그 ID
+     * @param idx 블로그 ID
      * @return BlogEntity 블로그 엔티티
      */
     private BlogEntity getBlogEntity(Long idx) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/usecase/BlogUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/usecase/BlogUseCase.java
@@ -25,8 +25,7 @@ public class BlogUseCase {
 
     /**
      * 블로그 등록
-     * @param request RegisterBlogRequest 블로그 등록 요청 정보
-     * @return void
+     * @param request 블로그 등록 요청 정보
      */
     public void registerBlog(RegisterBlogRequest request) {
         log.info("[BlogUseCase] registerBlog - titleKr={}", request.titleKr());
@@ -41,7 +40,7 @@ public class BlogUseCase {
 
     /**
      * 블로그 단건 조회
-     * @param idx Long 블로그 식별자
+     * @param idx 블로그 식별자
      * @return BlogResponse 블로그 응답
      */
     public BlogResponse getBlog(Long idx) {
@@ -52,7 +51,7 @@ public class BlogUseCase {
 
     /**
      * 블로그 목록 페이지 조회
-     * @param request PageRequest 페이지 요청 정보
+     * @param request 페이지 요청 정보
      * @return List<BlogResponse> 블로그 응답 목록
      */
     public List<BlogResponse> getAllBlogList(PageRequest request) {
@@ -66,8 +65,8 @@ public class BlogUseCase {
 
     /**
      * 제목으로 블로그 검색
-     * @param request PageRequest 페이지 요청 정보
-     * @param title String 검색할 블로그 제목
+     * @param request 페이지 요청 정보
+     * @param title 검색할 블로그 제목
      * @return List<BlogResponse> 블로그 응답 목록
      */
     public List<BlogResponse> searchBlogByTitle(PageRequest request, String title) {
@@ -81,8 +80,7 @@ public class BlogUseCase {
 
     /**
      * 블로그 수정
-     * @param request EditBlogRequest 블로그 수정 요청 정보
-     * @return void
+     * @param request 블로그 수정 요청 정보
      */
     public void updateBlog(EditBlogRequest request) {
         log.info("[BlogUseCase] updateBlog - idx={}", request.idx());
@@ -98,8 +96,7 @@ public class BlogUseCase {
 
     /**
      * 블로그 삭제
-     * @param idx Long 블로그 식별자
-     * @return void
+     * @param idx 블로그 식별자
      */
     public void deleteBlog(Long idx) {
         log.info("[BlogUseCase] deleteBlog - idx={}", idx);
@@ -108,8 +105,7 @@ public class BlogUseCase {
 
     /**
      * 블로그 조회수 증가
-     * @param idx Long 블로그 식별자
-     * @return void
+     * @param idx 블로그 식별자
      */
     public void addViews(Long idx) {
         log.info("[BlogUseCase] addViews - idx={}", idx);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/domain/entity/BlogEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/domain/entity/BlogEntity.java
@@ -56,11 +56,11 @@ public class BlogEntity extends BaseEntity {
 
     /**
      * 블로그 정보를 수정한다
-     * @param titleKr String 한국어 제목
-     * @param titleEn String 영문 제목
-     * @param contentKr String 한국어 내용
-     * @param contentEn String 영문 내용
-     * @param imageUrl String 대표 이미지 URL
+     * @param titleKr 한국어 제목
+     * @param titleEn 영문 제목
+     * @param contentKr 한국어 내용
+     * @param contentEn 영문 내용
+     * @param imageUrl 대표 이미지 URL
      */
     public void editBlog(
             String titleKr,

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/domain/model/Blog.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/domain/model/Blog.java
@@ -19,7 +19,7 @@ public record Blog(
 ) {
     /**
      * BlogEntity를 Blog 도메인 객체로 변환합니다.
-     * @param entity BlogEntity 변환할 엔티티
+     * @param entity 변환할 엔티티
      * @return Blog 변환된 도메인 객체
      */
     public static Blog of(BlogEntity entity) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/query/JobQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/query/JobQueryService.java
@@ -25,7 +25,7 @@ public class JobQueryService {
 
     /**
      * ID로 채용 공고 조회
-     * @param idx Long 채용 공고 ID
+     * @param idx 채용 공고 ID
      * @return Job 채용 공고 도메인 객체
      */
     public Job find(Long idx) {
@@ -37,8 +37,7 @@ public class JobQueryService {
 
     /**
      * 채용 공고 만료 여부 검증 (비활성 시 예외 발생)
-     * @param job Job 검증할 채용 공고 도메인 객체
-     * @return void
+     * @param job 검증할 채용 공고 도메인 객체
      */
     public void checkIsExpired(Job job) {
         if (!job.isActive()) {
@@ -48,12 +47,12 @@ public class JobQueryService {
 
     /**
      * 활성 채용 공고 목록 조건 조회
-     * @param page int 페이지 번호
-     * @param size int 페이지 크기
-     * @param title String 검색할 채용 공고 제목
-     * @param department Department 부서 필터
-     * @param education Education 학력 필터
-     * @param recruitType RecruitType 채용 유형 필터
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param title 검색할 채용 공고 제목
+     * @param department 부서 필터
+     * @param education 학력 필터
+     * @param recruitType 채용 유형 필터
      * @return List<Job> 채용 공고 도메인 객체 목록
      */
     public List<Job> findJobList(
@@ -76,12 +75,12 @@ public class JobQueryService {
 
     /**
      * 비활성 채용 공고 목록 조건 조회
-     * @param page int 페이지 번호
-     * @param size int 페이지 크기
-     * @param title String 검색할 채용 공고 제목
-     * @param department Department 부서 필터
-     * @param education Education 학력 필터
-     * @param recruitType RecruitType 채용 유형 필터
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param title 검색할 채용 공고 제목
+     * @param department 부서 필터
+     * @param education 학력 필터
+     * @param recruitType 채용 유형 필터
      * @return List<Job> 채용 공고 도메인 객체 목록
      */
     public List<Job> findDeactivateJobList(

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/response/JobResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/response/JobResponse.java
@@ -32,7 +32,7 @@ public record JobResponse(
 ) {
     /**
      * Job 도메인 객체를 JobResponse로 변환합니다.
-     * @param job Job 변환할 도메인 객체
+     * @param job 변환할 도메인 객체
      * @return JobResponse 변환된 응답 DTO
      */
     public static JobResponse of(Job job) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
@@ -18,8 +18,7 @@ public class JobService {
 
     /**
      * 채용 공고 저장
-     * @param input JobInput 채용 공고 입력 데이터
-     * @return void
+     * @param input 채용 공고 입력 데이터
      */
     @Transactional
     public void save(JobInput input) {
@@ -29,9 +28,8 @@ public class JobService {
 
     /**
      * 채용 공고 수정
-     * @param idx Long 채용 공고 ID
-     * @param input JobInput 채용 공고 입력 데이터
-     * @return void
+     * @param idx 채용 공고 ID
+     * @param input 채용 공고 입력 데이터
      */
     @Transactional
     public void edit(Long idx, JobInput input) {
@@ -44,8 +42,7 @@ public class JobService {
 
     /**
      * 채용 공고 비활성화
-     * @param idx Long 채용 공고 ID
-     * @return void
+     * @param idx 채용 공고 ID
      */
     @Transactional
     public void deactivate(Long idx) {
@@ -59,8 +56,7 @@ public class JobService {
     /**
      * 채용 공고 삭제 (존재하지 않으면 JobNotFoundException).
      * `edit`/`deactivate`와 동일하게 존재 여부를 명시적으로 검증해 404 응답 contract을 유지한다.
-     * @param idx Long 채용 공고 ID
-     * @return void
+     * @param idx 채용 공고 ID
      */
     @Transactional
     public void delete(Long idx) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/usecase/JobUseCase.java
@@ -25,8 +25,7 @@ public class JobUseCase {
 
     /**
      * 채용 공고 등록
-     * @param request RegisterJobRequest 채용 공고 등록 요청 정보
-     * @return void
+     * @param request 채용 공고 등록 요청 정보
      */
     public void registerJob(RegisterJobRequest request) {
         log.info("[JobUseCase] registerJob - title={}", request.title());
@@ -35,7 +34,7 @@ public class JobUseCase {
 
     /**
      * 채용 공고 단건 조회
-     * @param idx Long 채용 공고 식별자
+     * @param idx 채용 공고 식별자
      * @return JobResponse 채용 공고 응답
      */
     public JobResponse getJob(Long idx) {
@@ -45,7 +44,7 @@ public class JobUseCase {
 
     /**
      * 활성 채용 공고 목록 조회
-     * @param request GetJobListRequest 채용 공고 목록 조회 요청 정보
+     * @param request 채용 공고 목록 조회 요청 정보
      * @return List<JobResponse> 채용 공고 응답 목록
      */
     public List<JobResponse> getJobList(GetJobListRequest request) {
@@ -64,7 +63,7 @@ public class JobUseCase {
 
     /**
      * 비활성 채용 공고 목록 조회
-     * @param request GetJobListRequest 채용 공고 목록 조회 요청 정보
+     * @param request 채용 공고 목록 조회 요청 정보
      * @return List<JobResponse> 비활성 채용 공고 응답 목록
      */
     public List<JobResponse> getDeactivateJobList(GetJobListRequest request) {
@@ -83,8 +82,7 @@ public class JobUseCase {
 
     /**
      * 채용 공고 수정
-     * @param request EditJobRequest 채용 공고 수정 요청 정보
-     * @return void
+     * @param request 채용 공고 수정 요청 정보
      */
     public void updateJob(EditJobRequest request) {
         log.info("[JobUseCase] updateJob - idx={}", request.idx());
@@ -93,8 +91,7 @@ public class JobUseCase {
 
     /**
      * 채용 공고 비활성화
-     * @param idx Long 채용 공고 식별자
-     * @return void
+     * @param idx 채용 공고 식별자
      */
     public void deactivateJob(Long idx) {
         log.info("[JobUseCase] deactivateJob - idx={}", idx);
@@ -103,8 +100,7 @@ public class JobUseCase {
 
     /**
      * 채용 공고 삭제
-     * @param idx Long 채용 공고 식별자
-     * @return void
+     * @param idx 채용 공고 식별자
      */
     public void deleteJob(Long idx) {
         log.info("[JobUseCase] deleteJob - idx={}", idx);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/entity/JobEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/entity/JobEntity.java
@@ -94,7 +94,7 @@ public class JobEntity extends BaseEntity {
 
     /**
      * JobInput으로 새 활성 상태 채용 공고 엔티티를 생성한다
-     * @param input JobInput 채용 공고 입력 데이터
+     * @param input 채용 공고 입력 데이터
      * @return JobEntity 신규 채용 공고 엔티티
      */
     public static JobEntity create(JobInput input) {
@@ -118,7 +118,7 @@ public class JobEntity extends BaseEntity {
 
     /**
      * 채용 공고 정보를 수정한다
-     * @param input JobInput 채용 공고 입력 데이터
+     * @param input 채용 공고 입력 데이터
      */
     public void editJob(JobInput input) {
         this.title = input.title();

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/model/Job.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/model/Job.java
@@ -32,7 +32,7 @@ public record Job(
 ) {
     /**
      * JobEntity를 Job 도메인 객체로 변환합니다.
-     * @param entity JobEntity 변환할 엔티티
+     * @param entity 변환할 엔티티
      * @return Job 변환된 도메인 객체
      */
     public static Job of(JobEntity entity) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/repository/jpa/JobJpaRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/domain/repository/jpa/JobJpaRepository.java
@@ -32,8 +32,8 @@ public interface JobJpaRepository extends JpaRepository<JobEntity, Long> {
      * entity hydration 없이 단일 UPDATE를 실행하므로 메모리/I/O 비용이 일정하고,
      * 스케줄러가 특정 일자에 실행되지 못해 누락된 데이터까지 다음 실행에서 처리된다.
      * 벌크 UPDATE는 JPA Auditing을 우회하므로 modifiedAt을 쿼리에 명시한다.
-     * @param endDate LocalDate 비활성화 기준일 (해당 일 포함, 이전 데이터까지 처리)
-     * @param modifiedAt LocalDateTime 갱신 시각
+     * @param endDate 비활성화 기준일 (해당 일 포함, 이전 데이터까지 처리)
+     * @param modifiedAt 갱신 시각
      * @return int 영향받은 row 수
      */
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/query/NewsQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/query/NewsQueryService.java
@@ -21,7 +21,7 @@ public class NewsQueryService {
 
     /**
      * ID로 뉴스 조회
-     * @param idx Long 뉴스 ID
+     * @param idx 뉴스 ID
      * @return News 뉴스 도메인 객체
      */
     public News find(Long idx) {
@@ -33,8 +33,8 @@ public class NewsQueryService {
 
     /**
      * 뉴스 목록 페이지 조회
-     * @param page int 페이지 번호
-     * @param size int 페이지 크기
+     * @param page 페이지 번호
+     * @param size 페이지 크기
      * @return List<News> 뉴스 도메인 객체 목록
      */
     public List<News> findAll(int page, int size) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/response/NewsResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/response/NewsResponse.java
@@ -17,7 +17,7 @@ public record NewsResponse(
 ) {
     /**
      * News 도메인 객체를 NewsResponse로 변환합니다.
-     * @param news News 변환할 도메인 객체
+     * @param news 변환할 도메인 객체
      * @return NewsResponse 변환된 응답 DTO
      */
     public static NewsResponse of(News news) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/service/NewsService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/service/NewsService.java
@@ -17,11 +17,10 @@ public class NewsService {
 
     /**
      * 뉴스 저장
-     * @param titleKr String 한국어 제목
-     * @param titleEn String 영어 제목
-     * @param newsUrl String 뉴스 URL
-     * @param thumbnailImageUrl String 썸네일 이미지 URL
-     * @return void
+     * @param titleKr 한국어 제목
+     * @param titleEn 영어 제목
+     * @param newsUrl 뉴스 URL
+     * @param thumbnailImageUrl 썸네일 이미지 URL
      */
     @Transactional
     public void save(String titleKr, String titleEn, String newsUrl, String thumbnailImageUrl) {
@@ -36,12 +35,11 @@ public class NewsService {
 
     /**
      * 뉴스 수정
-     * @param idx Long 뉴스 ID
-     * @param titleKr String 한국어 제목
-     * @param titleEn String 영어 제목
-     * @param newsUrl String 뉴스 URL
-     * @param thumbnailImageUrl String 썸네일 이미지 URL
-     * @return void
+     * @param idx 뉴스 ID
+     * @param titleKr 한국어 제목
+     * @param titleEn 영어 제목
+     * @param newsUrl 뉴스 URL
+     * @param thumbnailImageUrl 썸네일 이미지 URL
      */
     @Transactional
     public void edit(Long idx, String titleKr, String titleEn, String newsUrl, String thumbnailImageUrl) {
@@ -52,8 +50,7 @@ public class NewsService {
 
     /**
      * 뉴스 삭제
-     * @param idx Long 뉴스 ID
-     * @return void
+     * @param idx 뉴스 ID
      */
     @Transactional
     public void delete(Long idx) {
@@ -64,7 +61,7 @@ public class NewsService {
 
     /**
      * ID로 NewsEntity 조회 (내부용)
-     * @param idx Long 뉴스 ID
+     * @param idx 뉴스 ID
      * @return NewsEntity 뉴스 엔티티
      */
     private NewsEntity getNewsEntity(Long idx) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/usecase/NewsUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/application/usecase/NewsUseCase.java
@@ -25,8 +25,7 @@ public class NewsUseCase {
 
     /**
      * 뉴스 등록
-     * @param request RegisterNewsRequest 뉴스 등록 요청 정보
-     * @return void
+     * @param request 뉴스 등록 요청 정보
      */
     public void registerNews(RegisterNewsRequest request) {
         log.info("[NewsUseCase] registerNews - titleKr={}", request.titleKr());
@@ -40,7 +39,7 @@ public class NewsUseCase {
 
     /**
      * 뉴스 단건 조회
-     * @param idx Long 뉴스 식별자
+     * @param idx 뉴스 식별자
      * @return NewsResponse 뉴스 응답
      */
     public NewsResponse getNews(Long idx) {
@@ -51,7 +50,7 @@ public class NewsUseCase {
 
     /**
      * 뉴스 목록 페이지 조회
-     * @param request PageRequest 페이지 요청 정보
+     * @param request 페이지 요청 정보
      * @return List<NewsResponse> 뉴스 응답 목록
      */
     public List<NewsResponse> getAllNewsList(PageRequest request) {
@@ -65,8 +64,7 @@ public class NewsUseCase {
 
     /**
      * 뉴스 수정
-     * @param request EditNewsRequest 뉴스 수정 요청 정보
-     * @return void
+     * @param request 뉴스 수정 요청 정보
      */
     public void updateNews(EditNewsRequest request) {
         log.info("[NewsUseCase] updateNews - idx={}", request.idx());
@@ -81,8 +79,7 @@ public class NewsUseCase {
 
     /**
      * 뉴스 삭제
-     * @param idx Long 뉴스 식별자
-     * @return void
+     * @param idx 뉴스 식별자
      */
     public void deleteNews(Long idx) {
         log.info("[NewsUseCase] deleteNews - idx={}", idx);

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/domain/entity/NewsEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/domain/entity/NewsEntity.java
@@ -42,10 +42,10 @@ public class NewsEntity extends BaseEntity {
 
     /**
      * 뉴스 정보를 수정한다
-     * @param titleKr String 한국어 제목
-     * @param titleEn String 영문 제목
-     * @param newsUrl String 뉴스 URL
-     * @param thumbnailImageUrl String 썸네일 이미지 URL
+     * @param titleKr 한국어 제목
+     * @param titleEn 영문 제목
+     * @param newsUrl 뉴스 URL
+     * @param thumbnailImageUrl 썸네일 이미지 URL
      */
     public void editNews(
             String titleKr,

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/domain/model/News.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/domain/model/News.java
@@ -17,7 +17,7 @@ public record News(
 ) {
     /**
      * NewsEntity를 News 도메인 객체로 변환합니다.
-     * @param entity NewsEntity 변환할 엔티티
+     * @param entity 변환할 엔티티
      * @return News 변환된 도메인 객체
      */
     public static News of(NewsEntity entity) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/constant/RecruitMailSubject.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/constant/RecruitMailSubject.java
@@ -19,7 +19,7 @@ public final class RecruitMailSubject {
 
     /**
      * 지원 접수 완료 안내 이메일 제목
-     * @param name String 지원자 이름
+     * @param name 지원자 이름
      * @return String 이메일 제목
      */
     public static String applyConfirmed(String name) {
@@ -28,7 +28,7 @@ public final class RecruitMailSubject {
 
     /**
      * 면접 전형 안내 이메일 제목
-     * @param name String 지원자 이름
+     * @param name 지원자 이름
      * @return String 이메일 제목
      */
     public static String interviewGuide(String name) {
@@ -37,7 +37,7 @@ public final class RecruitMailSubject {
 
     /**
      * 채용 전형 최종 결과(합격/불합격 공통) 안내 이메일 제목
-     * @param name String 지원자 이름
+     * @param name 지원자 이름
      * @return String 이메일 제목
      */
     public static String finalResult(String name) {
@@ -46,8 +46,8 @@ public final class RecruitMailSubject {
 
     /**
      * 공통 포맷: `{PREFIX} {name}님, {message}` — 호칭/구분자 변경 시 이 메서드만 수정.
-     * @param name String 수신자 이름
-     * @param message String 안내 메시지 본문
+     * @param name 수신자 이름
+     * @param message 안내 메시지 본문
      * @return String 조립된 이메일 제목
      */
     private static String personalized(String name, String message) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/query/RecruitQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/query/RecruitQueryService.java
@@ -23,7 +23,7 @@ public class RecruitQueryService {
 
     /**
      * ID로 지원서 조회
-     * @param idx Long 지원서 ID
+     * @param idx 지원서 ID
      * @return Recruit 지원서 도메인 객체
      */
     public Recruit find(Long idx) {
@@ -35,10 +35,10 @@ public class RecruitQueryService {
 
     /**
      * 페이지네이션 + jobId/status 필터로 지원서 목록 조회
-     * @param page int 페이지 번호 (1부터 시작)
-     * @param size int 페이지 크기
-     * @param jobId Long 채용 공고 ID (필수)
-     * @param status Status 지원서 상태 (nullable)
+     * @param page 페이지 번호 (1부터 시작)
+     * @param size 페이지 크기
+     * @param jobId 채용 공고 ID (필수)
+     * @param status 지원서 상태 (nullable)
      * @return List<Recruit> 지원서 도메인 객체 목록
      */
     public List<Recruit> findAllRecruits(
@@ -52,8 +52,7 @@ public class RecruitQueryService {
 
     /**
      * 지원서 상태 검증 (서류 전형 상태인 경우 예외 발생)
-     * @param recruit Recruit 검증할 지원서 도메인 객체
-     * @return void
+     * @param recruit 검증할 지원서 도메인 객체
      */
     public void checkStatus(Recruit recruit) {
         if (recruit.status().equals(Status.DOCUMENT)) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/response/RecruitResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/response/RecruitResponse.java
@@ -35,7 +35,7 @@ public record RecruitResponse(
 ) {
     /**
      * Recruit 도메인 객체를 RecruitResponse로 변환합니다.
-     * @param recruit Recruit 변환할 도메인 객체
+     * @param recruit 변환할 도메인 객체
      * @return RecruitResponse 변환된 응답 DTO
      */
     public static RecruitResponse of(Recruit recruit) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
@@ -21,7 +21,7 @@ public class RecruitService {
 
     /**
      * 채용 지원서 저장
-     * @param input RecruitInput 채용 지원서 입력 데이터
+     * @param input 채용 지원서 입력 데이터
      * @return Recruit 도메인 객체
      */
     @Transactional
@@ -33,9 +33,8 @@ public class RecruitService {
 
     /**
      * 지원서 상태 변경
-     * @param status Status 변경할 상태
-     * @param idx Long 지원서 ID
-     * @return void
+     * @param status 변경할 상태
+     * @param idx 지원서 ID
      */
     @Transactional
     public void editStatus(Status status, Long idx) {
@@ -48,8 +47,7 @@ public class RecruitService {
 
     /**
      * 지원자 최종 합격 처리
-     * @param idx Long 지원서 ID
-     * @return void
+     * @param idx 지원서 ID
      */
     @Transactional
     public void accept(Long idx) {
@@ -62,8 +60,7 @@ public class RecruitService {
 
     /**
      * 지원자 최종 불합격 처리
-     * @param idx Long 지원서 ID
-     * @return void
+     * @param idx 지원서 ID
      */
     @Transactional
     public void reject(Long idx) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -35,8 +35,7 @@ public class RecruitUseCase {
 
     /**
      * 채용 지원 등록 (지원 접수 확인 이메일 + 슬랙 알림 발송)
-     * @param request RegisterRecruitRequest 채용 지원 등록 요청 정보
-     * @return void
+     * @param request 채용 지원 등록 요청 정보
      */
     public void registerRecruit(RegisterRecruitRequest request) {
         log.info("[RecruitUseCase] registerRecruit - jobId={}, name={}", request.jobId(), request.name());
@@ -62,7 +61,7 @@ public class RecruitUseCase {
 
     /**
      * 지원서 단건 조회
-     * @param idx Long 지원서 식별자
+     * @param idx 지원서 식별자
      * @return RecruitResponse 지원서 응답
      */
     public RecruitResponse getRecruit(Long idx) {
@@ -73,7 +72,7 @@ public class RecruitUseCase {
 
     /**
      * 페이지네이션 + jobId/status 필터로 지원서 목록 조회
-     * @param request GetRecruitListRequest 지원서 목록 조회 요청 (page, size, jobId, status)
+     * @param request 지원서 목록 조회 요청 (page, size, jobId, status)
      * @return List<RecruitResponse> 지원서 응답 목록
      */
     public List<RecruitResponse> getRecruitList(GetRecruitListRequest request) {
@@ -92,9 +91,8 @@ public class RecruitUseCase {
 
     /**
      * 지원서 상태 변경 (면접 안내 이메일 발송)
-     * @param status Status 변경할 지원서 상태
-     * @param idx Long 지원서 식별자
-     * @return void
+     * @param status 변경할 지원서 상태
+     * @param idx 지원서 식별자
      */
     @Transactional
     public void updateStatus(Status status, Long idx) {
@@ -111,8 +109,7 @@ public class RecruitUseCase {
 
     /**
      * 지원자 최종 합격 처리 (합격 이메일 발송)
-     * @param idx Long 지원서 식별자
-     * @return void
+     * @param idx 지원서 식별자
      */
     @Transactional
     public void acceptRecruit(Long idx) {
@@ -130,8 +127,7 @@ public class RecruitUseCase {
 
     /**
      * 지원자 최종 불합격 처리 (불합격 이메일 발송)
-     * @param idx Long 지원서 식별자
-     * @return void
+     * @param idx 지원서 식별자
      */
     @Transactional
     public void rejectRecruit(Long idx) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
@@ -56,7 +56,7 @@ public record RegisterRecruitRequest(
 ) {
     /**
      * Request DTO를 RecruitInput 도메인 입력 데이터로 변환한다 (jobId 오버라이드 지원)
-     * @param resolvedJobId Long 검증/조회된 채용 공고 ID
+     * @param resolvedJobId 검증/조회된 채용 공고 ID
      * @return RecruitInput 채용 지원서 입력 데이터
      */
     public RecruitInput toRecruitInput(Long resolvedJobId) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/entity/RecruitEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/entity/RecruitEntity.java
@@ -104,7 +104,7 @@ public class RecruitEntity extends BaseEntity {
 
     /**
      * RecruitInput으로 새 지원서 엔티티를 생성한다 (서류 전형 상태)
-     * @param input RecruitInput 채용 지원서 입력 데이터
+     * @param input 채용 지원서 입력 데이터
      * @return RecruitEntity 신규 지원서 엔티티
      */
     public static RecruitEntity create(RecruitInput input) {
@@ -133,7 +133,7 @@ public class RecruitEntity extends BaseEntity {
 
     /**
      * 지원서 전형 상태를 변경한다
-     * @param status Status 변경할 전형 상태
+     * @param status 변경할 전형 상태
      */
     public void editStatus(Status status) {
         this.status = status;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/model/Recruit.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/model/Recruit.java
@@ -35,7 +35,7 @@ public record Recruit(
 ) {
     /**
      * RecruitEntity를 Recruit 도메인 객체로 변환합니다.
-     * @param entity RecruitEntity 변환할 엔티티
+     * @param entity 변환할 엔티티
      * @return Recruit 변환된 도메인 객체
      */
     public static Recruit of(RecruitEntity entity) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/repository/query/RecruitQueryRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/domain/repository/query/RecruitQueryRepository.java
@@ -19,10 +19,10 @@ public class RecruitQueryRepository {
 
     /**
      * 페이지네이션 + jobId/status 필터로 지원서 목록 조회
-     * @param page int 페이지 번호 (1부터 시작)
-     * @param size int 페이지 크기
-     * @param jobId Long 채용 공고 ID (필수)
-     * @param status Status 지원서 상태 (nullable)
+     * @param page 페이지 번호 (1부터 시작)
+     * @param size 페이지 크기
+     * @param jobId 채용 공고 ID (필수)
+     * @param status 지원서 상태 (nullable)
      * @return List<Recruit> 지원서 도메인 객체 목록
      */
     public List<Recruit> findRecruits(
@@ -46,8 +46,8 @@ public class RecruitQueryRepository {
 
     /**
      * jobId/status 조건 BooleanBuilder 생성
-     * @param jobId Long 채용 공고 ID (필수, null 시 IllegalArgumentException)
-     * @param status Status 지원서 상태 (nullable)
+     * @param jobId 채용 공고 ID (필수, null 시 IllegalArgumentException)
+     * @param status 지원서 상태 (nullable)
      * @return BooleanBuilder QueryDSL 조건 빌더
      */
     private BooleanBuilder builder(

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/query/TalentQueryService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/query/TalentQueryService.java
@@ -21,7 +21,7 @@ public class TalentQueryService {
 
     /**
      * ID로 인재 조회
-     * @param idx Long 인재 ID
+     * @param idx 인재 ID
      * @return Talent 인재 도메인 객체
      */
     public Talent find(Long idx) {
@@ -33,8 +33,7 @@ public class TalentQueryService {
 
     /**
      * 이메일 중복 검증 (중복 시 예외 발생)
-     * @param email String 검증할 이메일 주소
-     * @return void
+     * @param email 검증할 이메일 주소
      */
     public void checkExistsByEmail(String email) {
         if (talentJpaRepository.existsByEmail(email)) {
@@ -44,9 +43,9 @@ public class TalentQueryService {
 
     /**
      * 인재풀 목록 조회
-     * @param isActive boolean 활성 여부
-     * @param page int 페이지 번호
-     * @param size int 페이지 크기
+     * @param isActive 활성 여부
+     * @param page 페이지 번호
+     * @param size 페이지 크기
      * @return List<Talent> 인재 도메인 객체 목록
      */
     public List<Talent> findAllTalents(
@@ -63,9 +62,9 @@ public class TalentQueryService {
 
     /**
      * 인재풀 키워드 검색
-     * @param keyword String 검색 키워드
-     * @param page int 페이지 번호
-     * @param size int 페이지 크기
+     * @param keyword 검색 키워드
+     * @param page 페이지 번호
+     * @param size 페이지 크기
      * @return List<Talent> 인재 도메인 객체 목록
      */
     public List<Talent> searchTalents(

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/response/TalentResponse.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/response/TalentResponse.java
@@ -18,7 +18,7 @@ public record TalentResponse(
 ) {
     /**
      * Talent 도메인 객체를 TalentResponse로 변환합니다.
-     * @param talent Talent 변환할 도메인 객체
+     * @param talent 변환할 도메인 객체
      * @return TalentResponse 변환된 응답 DTO
      */
     public static TalentResponse of(Talent talent) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
@@ -19,12 +19,11 @@ public class TalentService {
 
     /**
      * 인재풀 등록
-     * @param email String 이메일
-     * @param name String 이름
-     * @param department String 부서
-     * @param portfolioUrl String 포트폴리오 URL
-     * @param etcUrl List<String> 기타 URL 목록
-     * @return void
+     * @param email 이메일
+     * @param name 이름
+     * @param department 부서
+     * @param portfolioUrl 포트폴리오 URL
+     * @param etcUrl 기타 URL 목록
      */
     @Transactional
     public void save(
@@ -47,9 +46,8 @@ public class TalentService {
 
     /**
      * 인재 활성 상태 변경
-     * @param idx Long 인재 ID
-     * @param isActive boolean 활성 여부
-     * @return void
+     * @param idx 인재 ID
+     * @param isActive 활성 여부
      */
     @Transactional
     public void editActive(Long idx, boolean isActive) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
@@ -32,8 +32,7 @@ public class TalentUseCase {
 
     /**
      * 인재풀 등록 (등록 확인 이메일 발송)
-     * @param request RegisterTalentRequest 인재풀 등록 요청 정보
-     * @return void
+     * @param request 인재풀 등록 요청 정보
      */
     public void registerTalent(RegisterTalentRequest request) {
         log.info("[TalentUseCase] registerTalent - email={}, name={}", request.email(), request.name());
@@ -51,8 +50,7 @@ public class TalentUseCase {
 
     /**
      * 인재풀 대상 면접 제안 이메일 발송
-     * @param request SendEmailToTalentRequest 인재 이메일 발송 요청 정보
-     * @return void
+     * @param request 인재 이메일 발송 요청 정보
      */
     public void sendMailToTalent(SendEmailToTalentRequest request) {
         log.info("[TalentUseCase] sendMailToTalent - idx={}", request.idx());
@@ -64,7 +62,7 @@ public class TalentUseCase {
 
     /**
      * 인재 단건 조회
-     * @param idx Long 인재 식별자
+     * @param idx 인재 식별자
      * @return TalentResponse 인재 응답
      */
     public TalentResponse getTalent(Long idx) {
@@ -75,7 +73,7 @@ public class TalentUseCase {
 
     /**
      * 인재풀 목록 조회
-     * @param request GetTalentListRequest 인재풀 목록 조회 요청 정보
+     * @param request 인재풀 목록 조회 요청 정보
      * @return List<TalentResponse> 인재 응답 목록
      */
     public List<TalentResponse> getTalentList(GetTalentListRequest request) {
@@ -87,7 +85,7 @@ public class TalentUseCase {
 
     /**
      * 인재풀 키워드 검색
-     * @param request SearchTalentRequest 인재풀 검색 요청 정보
+     * @param request 인재풀 검색 요청 정보
      * @return List<TalentResponse> 인재 응답 목록
      */
     public List<TalentResponse> searchTalent(SearchTalentRequest request) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/entity/TalentEntity.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/entity/TalentEntity.java
@@ -61,7 +61,7 @@ public class TalentEntity extends BaseEntity {
 
     /**
      * 인재의 활성 상태를 변경한다
-     * @param isActive boolean 활성 여부
+     * @param isActive 활성 여부
      */
     public void editActive(boolean isActive) {
         this.isActive = isActive;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/model/Talent.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/domain/model/Talent.java
@@ -19,7 +19,7 @@ public record Talent(
 ) {
     /**
      * TalentEntity를 Talent 도메인 객체로 변환합니다.
-     * @param entity TalentEntity 변환할 엔티티
+     * @param entity 변환할 엔티티
      * @return Talent 변환된 도메인 객체
      */
     public static Talent of(TalentEntity entity) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/repository/redis/RedisRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/repository/redis/RedisRepository.java
@@ -6,24 +6,24 @@ public interface RedisRepository {
 
     /**
      * Redis에 값 저장 (TTL 포함)
-     * @param key String 저장 키
-     * @param value T 저장할 값
-     * @param timeout int 만료 시간
-     * @param unit TimeUnit 만료 시간 단위
+     * @param key 저장 키
+     * @param value 저장할 값
+     * @param timeout 만료 시간
+     * @param unit 만료 시간 단위
      */
     <T> void save(String key, T value, int timeout, TimeUnit unit);
 
     /**
      * Redis에서 키로 값 조회
-     * @param key String 조회 키
-     * @param type Class<T> 반환 타입 클래스
+     * @param key 조회 키
+     * @param type 반환 타입 클래스
      * @return T 조회된 값
      */
     <T> T getByKey(String key, Class<T> type);
 
     /**
      * Redis에서 키 삭제
-     * @param key String 삭제할 키
+     * @param key 삭제할 키
      */
     void delete(String key);
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/repository/redis/impl/RedisRepositoryImpl.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/repository/redis/impl/RedisRepositoryImpl.java
@@ -15,10 +15,10 @@ public class RedisRepositoryImpl implements RedisRepository {
 
     /**
      * Redis에 값 저장 (TTL 포함)
-     * @param key String 저장 키
-     * @param value T 저장할 값
-     * @param timeout int 만료 시간
-     * @param unit TimeUnit 만료 시간 단위
+     * @param key 저장 키
+     * @param value 저장할 값
+     * @param timeout 만료 시간
+     * @param unit 만료 시간 단위
      */
     @Override
     public <T> void save(String key, T value, int timeout, TimeUnit unit) {
@@ -27,8 +27,8 @@ public class RedisRepositoryImpl implements RedisRepository {
 
     /**
      * Redis에서 키로 값 조회
-     * @param key String 조회 키
-     * @param type Class<T> 반환 타입 클래스
+     * @param key 조회 키
+     * @param type 반환 타입 클래스
      * @return T 조회된 값
      */
     @Override
@@ -38,7 +38,7 @@ public class RedisRepositoryImpl implements RedisRepository {
 
     /**
      * Redis에서 키 삭제
-     * @param key String 삭제할 키
+     * @param key 삭제할 키
      */
     @Override
     public void delete(String key) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/handler/ValidationExceptionAdvice.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/handler/ValidationExceptionAdvice.java
@@ -18,7 +18,7 @@ public class ValidationExceptionAdvice {
     /**
      * `@RequestBody @Valid`(MethodArgumentNotValidException) / `@ModelAttribute @Valid`(BindException) 양쪽 검증 실패를
      * BindException 부모 핸들러 하나로 통합 처리한다. MethodArgumentNotValidException은 BindException 자식.
-     * @param exception BindException 검증 실패 예외
+     * @param exception 검증 실패 예외
      * @return ErrorResponse 첫 검증 오류 메시지 응답
      */
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/email/renderer/MailTemplateRenderer.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/email/renderer/MailTemplateRenderer.java
@@ -17,7 +17,7 @@ public class MailTemplateRenderer {
 
     /**
      * 이메일 인증 코드 메일 템플릿 렌더링
-     * @param authCode String 인증 코드
+     * @param authCode 인증 코드
      * @return String HTML 내용
      */
     public String renderAuthCodeEmail(String authCode) {
@@ -28,8 +28,8 @@ public class MailTemplateRenderer {
 
     /**
      * 면접 전형 안내 메일 템플릿 렌더링
-     * @param name String 지원자 이름
-     * @param status Status 전형 상태
+     * @param name 지원자 이름
+     * @param status 전형 상태
      * @return String HTML 내용
      */
     public String renderRecruitEmail(String name, Status status) {
@@ -41,7 +41,7 @@ public class MailTemplateRenderer {
 
     /**
      * 최종 합격 안내 메일 템플릿 렌더링
-     * @param name String 지원자 이름
+     * @param name 지원자 이름
      * @return String HTML 내용
      */
     public String renderAcceptEmail(String name) {
@@ -52,7 +52,7 @@ public class MailTemplateRenderer {
 
     /**
      * 최종 불합격 안내 메일 템플릿 렌더링
-     * @param name String 지원자 이름
+     * @param name 지원자 이름
      * @return String HTML 내용
      */
     public String renderRejectEmail(String name) {
@@ -63,9 +63,9 @@ public class MailTemplateRenderer {
 
     /**
      * 지원 접수 확인 메일 템플릿 렌더링
-     * @param name String 지원자 이름
-     * @param position String 지원 포지션
-     * @param applicationDate LocalDateTime 지원 일시
+     * @param name 지원자 이름
+     * @param position 지원 포지션
+     * @param applicationDate 지원 일시
      * @return String HTML 내용
      */
     public String renderApplyConfirmEmail(String name, String position, LocalDateTime applicationDate) {
@@ -80,8 +80,8 @@ public class MailTemplateRenderer {
 
     /**
      * 인재풀 등록 확인 메일 템플릿 렌더링
-     * @param name String 지원자 이름
-     * @param createdAt LocalDateTime 등록 일시
+     * @param name 지원자 이름
+     * @param createdAt 등록 일시
      * @return String HTML 내용
      */
     public String renderTalentEmail(String name, LocalDateTime createdAt) {
@@ -95,8 +95,8 @@ public class MailTemplateRenderer {
 
     /**
      * 면접 제안 메일 템플릿 렌더링
-     * @param name String 지원자 이름
-     * @param text String 면접 제안 내용
+     * @param name 지원자 이름
+     * @param text 면접 제안 내용
      * @return String HTML 내용
      */
     public String renderOfferEmail(String name, String text) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/email/service/EmailService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/email/service/EmailService.java
@@ -16,8 +16,8 @@ public class EmailService {
 
     /**
      * 이메일 서비스 생성자 (noreply, recruit 발신자 주입)
-     * @param noreplyMailSender JavaMailSender noreply 계정 메일 발신자
-     * @param recruitMailSender JavaMailSender recruit 계정 메일 발신자
+     * @param noreplyMailSender noreply 계정 메일 발신자
+     * @param recruitMailSender recruit 계정 메일 발신자
      */
     public EmailService(
             @Qualifier("noreplyMailSender") JavaMailSender noreplyMailSender,
@@ -29,9 +29,9 @@ public class EmailService {
 
     /**
      * noreply 계정으로 이메일 비동기 발송
-     * @param to String 수신자 이메일 주소
-     * @param subject String 이메일 제목
-     * @param content String 이메일 내용 (HTML)
+     * @param to 수신자 이메일 주소
+     * @param subject 이메일 제목
+     * @param content 이메일 내용 (HTML)
      */
     @Async
     public void sendNoReply(String to, String subject, String content) {
@@ -40,9 +40,9 @@ public class EmailService {
 
     /**
      * recruit 계정으로 이메일 비동기 발송
-     * @param to String 수신자 이메일 주소
-     * @param subject String 이메일 제목
-     * @param content String 이메일 내용 (HTML)
+     * @param to 수신자 이메일 주소
+     * @param subject 이메일 제목
+     * @param content 이메일 내용 (HTML)
      */
     @Async
     public void sendRecruit(String to, String subject, String content) {
@@ -51,11 +51,11 @@ public class EmailService {
 
     /**
      * 이메일 발송 공통 로직
-     * @param sender JavaMailSender 메일 발신 객체
-     * @param from String 발신자 이메일 주소
-     * @param to String 수신자 이메일 주소
-     * @param subject String 이메일 제목
-     * @param content String 이메일 내용 (HTML)
+     * @param sender 메일 발신 객체
+     * @param from 발신자 이메일 주소
+     * @param to 수신자 이메일 주소
+     * @param subject 이메일 제목
+     * @param content 이메일 내용 (HTML)
      */
     public void send(JavaMailSender sender, String from, String to, String subject, String content) {
         MimeMessage message = sender.createMimeMessage();

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/gcp/service/GcpService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/gcp/service/GcpService.java
@@ -31,7 +31,7 @@ public class GcpService {
 
     /**
      * GCS에 파일 업로드
-     * @param multipartFile MultipartFile 업로드할 파일
+     * @param multipartFile 업로드할 파일
      * @return String 이미지 URL
      */
     public String upload(MultipartFile multipartFile) throws IOException {
@@ -52,7 +52,7 @@ public class GcpService {
 
     /**
      * GCS에서 파일 삭제
-     * @param fileUrl String 삭제할 파일 URL
+     * @param fileUrl 삭제할 파일 URL
      */
     public void delete(String fileUrl) {
         String fileName = extractFileNameFromUrl(fileUrl);
@@ -83,7 +83,7 @@ public class GcpService {
 
     /**
      * URL에서 파일명 추출
-     * @param url String 파일 URL
+     * @param url 파일 URL
      * @return String 파일명
      */
     private String extractFileNameFromUrl(String url) {
@@ -96,7 +96,7 @@ public class GcpService {
 
     /**
      * 파일 비어있는지 검증
-     * @param multipartFile MultipartFile 검증할 파일
+     * @param multipartFile 검증할 파일
      */
     private void checkFileIsEmpty(MultipartFile multipartFile) {
         if (multipartFile.isEmpty()) {
@@ -106,7 +106,7 @@ public class GcpService {
 
     /**
      * 허용된 파일 타입인지 검증 (PDF, PNG, JPG, JPEG, MP4)
-     * @param contentType String 파일 콘텐츠 타입
+     * @param contentType 파일 콘텐츠 타입
      */
     private void checkFileType(String contentType) {
         if (
@@ -122,7 +122,7 @@ public class GcpService {
 
     /**
      * GCS 이미지 URL 생성
-     * @param uuid String 파일 고유 식별자
+     * @param uuid 파일 고유 식별자
      * @return String URL
      */
     public String createImageUrl(String uuid) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
@@ -28,9 +28,9 @@ public class SlackNotifier {
 
     /**
      * 신규 지원자 알림을 Slack으로 발송
-     * @param jobTitle String 채용 공고 제목
-     * @param applicantName String 지원자 이름
-     * @param recruitIdx Long 채용 지원 식별자
+     * @param jobTitle 채용 공고 제목
+     * @param applicantName 지원자 이름
+     * @param recruitIdx 채용 지원 식별자
      */
     @Async
     public void sendApplicantNotification(String jobTitle, String applicantName, Long recruitIdx) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/auth/CustomUserDetails.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/auth/CustomUserDetails.java
@@ -16,7 +16,7 @@ public class CustomUserDetails implements UserDetails {
 
     /**
      * CustomUserDetails 생성자
-     * @param admin Admin 어드민 도메인 객체
+     * @param admin 어드민 도메인 객체
      */
     public CustomUserDetails(final Admin admin) {
         this.admin = admin;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/JwtExtract.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/JwtExtract.java
@@ -25,7 +25,7 @@ public class JwtExtract {
 
     /**
      * JWT 토큰에서 인증 정보 추출 및 Authentication 생성
-     * @param token String JWT 토큰 문자열
+     * @param token JWT 토큰 문자열
      * @return Authentication 인증 객체
      */
     public Authentication getAuthentication(final String token) {
@@ -44,7 +44,7 @@ public class JwtExtract {
 
     /**
      * HTTP 요청에서 JWT 토큰 추출
-     * @param request HttpServletRequest HTTP 요청 객체
+     * @param request HTTP 요청 객체
      * @return String 토큰
      */
     public String extractTokenFromRequest(HttpServletRequest request) {
@@ -53,7 +53,7 @@ public class JwtExtract {
 
     /**
      * Bearer 접두사 제거 후 토큰 반환
-     * @param token String Authorization 헤더 값
+     * @param token Authorization 헤더 값
      * @return String 토큰
      */
     public String extractToken(final String token) {
@@ -65,8 +65,8 @@ public class JwtExtract {
 
     /**
      * 토큰 타입 불일치 여부 확인
-     * @param claims Claims JWT 클레임 정보
-     * @param jwtType JwtType 기대하는 토큰 타입
+     * @param claims JWT 클레임 정보
+     * @param jwtType 기대하는 토큰 타입
      * @return boolean 불일치 여부
      */
     public boolean isWrongType(final Claims claims, final JwtType jwtType) {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/JwtProvider.java
@@ -36,7 +36,7 @@ public class JwtProvider {
 
     /**
      * JWT 토큰 파싱 및 검증
-     * @param token String JWT 토큰 문자열
+     * @param token JWT 토큰 문자열
      * @return Jws<Claims> 검증된 클레임 정보
      */
     public Jws<Claims> getClaims(final String token) {
@@ -60,8 +60,8 @@ public class JwtProvider {
 
     /**
      * 액세스 토큰 생성
-     * @param subject String 토큰 subject (어드민 ID)
-     * @param role String 권한 클레임 (예: ADMIN)
+     * @param subject 토큰 subject (어드민 ID)
+     * @param role 권한 클레임 (예: ADMIN)
      * @return String JWT 토큰
      */
     public String generateAccessToken(final String subject, final String role) {
@@ -81,7 +81,7 @@ public class JwtProvider {
 
     /**
      * 리프레시 토큰 생성
-     * @param subject String 토큰 subject (어드민 ID)
+     * @param subject 토큰 subject (어드민 ID)
      * @return String JWT 토큰
      */
     public String generateRefreshToken(final String subject) {


### PR DESCRIPTION
## 제목
java-code-style 준수: `@return void` 제거 및 `@param` 타입 토큰 제거

## 작업한 내용
- void 메서드의 `@return void` 43개 제거 (convention: void는 @return 생략)
- `@param`에서 타입 토큰 235개 제거 (대문자/제네릭/원시형) — 설명은 전부 보존 (convention: @param에 타입 미포함, 타입은 시그니처에 이미 존재)
- 53파일, 순수 javadoc 변경 (코드 라인 변경 0건)
- 로컬 `./gradlew compileJava` 통과

## 전달할 추가 이슈
- 자가 리뷰만 수행 — 본 PR이 피어 리뷰·CI 게이트 대상입니다.
- import 순서 / DTO 디렉토리 경로 / UseCase→Redis 직접주입 등은 별도 판단으로 이번 범위에서 제외.
- 연결 이슈 없음 (필요 시 Task 이슈 생성 후 Closes 링크 추가 가능).
