### PR TITLE
style/global-method-body

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
@@ -34,7 +34,6 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             chain.doFilter(request, response);
         } finally {
             int status = response.getStatus();
-
             org.slf4j.LoggerFactory.getLogger(RequestLoggingFilter.class).info(
                     "traceId={} ip={} method={} uri={}{} status={} ua={}",
                     traceId, clientIp, method, decodedUri, (query != null ? "?" + query : ""), status, ua

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/config/SecurityConfig.java
@@ -54,7 +54,6 @@ public class SecurityConfig implements WebMvcConfigurer {
                         authorize -> authorize
                                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                                 .requestMatchers("/", "/index.html").permitAll()
-
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                 .requestMatchers("/admin/email-verification/**").permitAll()
                                 .requestMatchers("/admin/webauthn/register/**").permitAll()

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -23,7 +23,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException, ExpiredJwtException {
-
         String token = jwtExtract.extractTokenFromRequest(request);
         if (token != null) {
             SecurityContextHolder.getContext().setAuthentication(jwtExtract.getAuthentication(token));

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -22,10 +22,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
-
-        var errorCode = ErrorCode.UNAUTHORIZED;
-        var body = BaseResponse.of(errorCode);
-
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
+        BaseResponse body = BaseResponse.of(errorCode);
         response.setStatus(errorCode.getStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());


### PR DESCRIPTION
## 제목
Prohibited 항목 정리: `var` 제거 및 메서드 내 빈 줄 제거

## 작업한 내용
- `JwtAuthenticationEntryPoint`의 `var` 2개 → 명시 타입(`ErrorCode`, `BaseResponse`)
- 메서드 내부 빈 줄 5개 제거 (JwtAuthenticationEntryPoint, SecurityConfig, RequestLoggingFilter, JwtAuthenticationFilter)
- 4파일, 로직 변경 없음 — `SecurityConfig`의 인증 규칙/순서/permitAll 목록 불변
- 로컬 `./gradlew compileJava` 통과

## 전달할 추가 이슈
- 자가 리뷰만 수행 — 본 PR이 피어 리뷰·CI 게이트 대상입니다.
- 연결 이슈 없음 (필요 시 Task 이슈 생성 후 Closes 링크 추가 가능).
