### PR TITLE
config/bump-vulnerable-deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,14 @@ repositories {
 
 ext {
     querydslVersion = "7.1"
-    set('tomcat.version', '11.0.21')
+    // tomcat 11.0.22: fixes CVEs (security-constraint bypass, digest-auth bypass, HTTP/2 header validation, WebDAV unbounded read)
+    set('tomcat.version', '11.0.22')
     set('thymeleaf.version', '3.1.5.RELEASE')
     set('jackson-bom.version', '3.1.2')
     set('netty.version', '4.2.13.Final')
+    // opentelemetry 1.62.0: fixes unbounded memory allocation in W3C baggage propagation
+    // (commons-lang3 already resolves to a patched 3.19.0 transitively — no override needed)
+    set('opentelemetry.version', '1.62.0')
 }
 
 dependencies {


### PR DESCRIPTION
## 제목
취약 의존성 버전 업 (Dependabot 보안 알림 대응)

## 작업한 내용
- `tomcat.version` 11.0.21 → **11.0.22**: critical/high CVE 다수 패치 (보안 제약 우회, Digest 인증 우회, HTTP/2 헤더 미검증, WebDAV 무제한 read)
- `opentelemetry.version` → **1.62.0**: W3C baggage 전파 시 무제한 메모리 할당 패치 (transitive 1.47/1.51 → 1.62 강제)
- commons-lang3는 transitive로 이미 patched(3.19.0) 해석되어 override 불필요 — 추가 안 함
- `dependencyInsight`로 3개 아티팩트 해석 버전 확인, `compileJava` 통과

## 전달할 추가 이슈
- Dependabot 잔여 알림은 머지 후 자동 해소 여부 확인 필요.
- 자가 리뷰만 수행 — 본 PR이 피어 리뷰·CI 게이트 대상.
