### PR TITLE
fix/cors-and-gcp-delete-auth

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                                 .requestMatchers(HttpMethod.GET, "/job").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/job/list").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/recruit").permitAll()
-                                .requestMatchers("/gcp/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/gcp").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/blog/**").permitAll()
                                 .requestMatchers(HttpMethod.PATCH, "/blog").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/news/**").permitAll()
@@ -92,7 +92,9 @@ public class SecurityConfig implements WebMvcConfigurer {
             "Origin",
             "Cache-Control"
         ));
-        config.setAllowCredentials(true);
+        // 인증은 Authorization 헤더(Bearer JWT) 기반이라 쿠키 자격증명이 불필요하다.
+        // allowedOriginPatterns("*") 와 allowCredentials(true) 조합은 임의 출처 credentialed 요청을 허용하는 취약 설정이므로 false 로 둔다.
+        config.setAllowCredentials(false);
         config.setMaxAge(Duration.ofHours(1));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
## 제목
인증 없는 파일 삭제(C1) 및 CORS 오설정(H1) 수정

## 작업한 내용
- **C1 (Critical)**: `/gcp/**` permitAll → `POST /gcp` 만 permitAll. `DELETE /gcp` 는 `anyRequest().authenticated()` 로 떨어져 **인증 필요**. (공개 GET /blog·/news로 노출된 객체명을 이용한 무인증 임의 파일 삭제 차단)
- **H1 (High)**: `setAllowCredentials(true)` → `false`. 인증이 Bearer 헤더 기반이라 쿠키 자격증명 불필요 — `allowedOriginPatterns("*")` + credentials 조합 취약점 제거.
- `compileJava` 통과.

## 전달할 추가 이슈
- 공개 업로드(POST /gcp)는 지원폼 위해 유지 — 클라이언트가 더 이상 DELETE로 본인 미사용 업로드를 정리할 수 없음(고아 객체 누적 가능). 필요 시 스케줄 클린업 별도 고려.
- 프런트가 쿠키 자격증명(withCredentials)을 쓰지 않는다는 전제. 쿠키 인증을 쓴다면 출처 화이트리스트 방식으로 변경 필요.
- 업로드 남용/콘텐츠 검증은 `feat/abuse-rate-limiting`에서 처리.
