### PR TITLE
feat/abuse-rate-limiting

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
@@ -2,6 +2,8 @@ package com.bigtablet.bigtablethompageserver.domain.admin.application.service;
 
 import com.bigtablet.bigtablethompageserver.domain.admin.exception.EmailCodeMismatchException;
 import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
+import com.bigtablet.bigtablethompageserver.global.common.util.RateLimiter;
+import com.bigtablet.bigtablethompageserver.global.exception.TooManyRequestsException;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
 import com.bigtablet.bigtablethompageserver.global.security.admin.config.AdminAuthProperties;
@@ -9,8 +11,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
-import java.util.Objects;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -23,11 +27,16 @@ public class EmailVerificationService {
     private static final String OTP_KEY_PREFIX = "admin-email-otp:";
     // 인증 완료 플래그 Redis 키 접두어
     private static final String CERT_KEY_PREFIX = "admin-email-cert:";
+    // 인증 시도 횟수 카운터 Redis 키 접두어
+    private static final String ATTEMPT_KEY_PREFIX = "admin-email-attempt:";
+    // OTP 검증 최대 시도 횟수 (초과 시 OTP 폐기 + 잠금)
+    private static final int MAX_VERIFY_ATTEMPTS = 5;
 
     private final RedisRepository redisRepository;
     private final EmailService emailService;
     private final MailTemplateRenderer mailTemplateRenderer;
     private final AdminAuthProperties adminAuthProperties;
+    private final RateLimiter rateLimiter;
 
     /**
      * 6자리 OTP 생성 후 Redis에 저장하고 이메일로 발송 (application.admin.otp-ttl 적용)
@@ -35,11 +44,16 @@ public class EmailVerificationService {
      * @return void
      */
     public void sendCode(String email) {
-        log.info("[EmailVerificationService] sendCode - email={}", email);
+        log.info("[EmailVerificationService] sendCode - email={}", mask(email));
         String normalized = email.toLowerCase();
+        // 발송 남용 방지: 동일 이메일 30초 1회 + 1시간 10회 제한
+        rateLimiter.check("admin-email-send-cd:" + normalized, 1, Duration.ofSeconds(30));
+        rateLimiter.check("admin-email-send:" + normalized, 10, Duration.ofHours(1));
         // 기존 OTP가 남아있으면 덮어쓰기 위해 선제거
         Optional.ofNullable(redisRepository.getByKey(OTP_KEY_PREFIX + normalized, String.class))
                 .ifPresent(value -> redisRepository.delete(OTP_KEY_PREFIX + normalized));
+        // 새 코드 발급 시 검증 시도 횟수 초기화
+        redisRepository.delete(ATTEMPT_KEY_PREFIX + normalized);
         SecureRandom r = new SecureRandom();
         StringBuilder code = new StringBuilder();
         for (int i = 0; i < 6; i++) {
@@ -58,14 +72,35 @@ public class EmailVerificationService {
      * @return void
      */
     public void verifyCode(String email, String authCode) {
-        log.info("[EmailVerificationService] verifyCode - email={}", email);
+        log.info("[EmailVerificationService] verifyCode - email={}", mask(email));
         String normalized = email.toLowerCase();
+        // 무차별 대입 방어: 시도 횟수를 OTP 수명 동안 누적, 초과 시 OTP 폐기 + 잠금
+        long attempts = redisRepository.increment(ATTEMPT_KEY_PREFIX + normalized, adminAuthProperties.otpTtl());
+        if (attempts > MAX_VERIFY_ATTEMPTS) {
+            redisRepository.delete(OTP_KEY_PREFIX + normalized);
+            throw TooManyRequestsException.EXCEPTION;
+        }
         String savedCode = redisRepository.getByKey(OTP_KEY_PREFIX + normalized, String.class);
-        if (savedCode == null || !Objects.equals(savedCode, authCode)) {
+        // 상수 시간 비교로 타이밍 사이드채널 차단
+        if (savedCode == null
+                || !MessageDigest.isEqual(savedCode.getBytes(StandardCharsets.UTF_8), authCode.getBytes(StandardCharsets.UTF_8))) {
             throw EmailCodeMismatchException.EXCEPTION;
         }
         redisRepository.delete(OTP_KEY_PREFIX + normalized);
+        redisRepository.delete(ATTEMPT_KEY_PREFIX + normalized);
         redisRepository.save(CERT_KEY_PREFIX + normalized, "1", (int) adminAuthProperties.certTtl().toSeconds(), TimeUnit.SECONDS);
+    }
+
+    // 이메일 로컬파트를 마스킹하여 로그 PII 노출을 줄인다 (예: a***@bigtablet.com)
+    private String mask(String email) {
+        if (email == null) {
+            return "null";
+        }
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return "***";
+        }
+        return email.charAt(0) + "***" + email.substring(at);
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/api/RecruitApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/api/RecruitApiHandler.java
@@ -7,6 +7,8 @@ import com.bigtablet.bigtablethompageserver.domain.recruit.client.dto.request.Re
 import com.bigtablet.bigtablethompageserver.domain.recruit.domain.enums.Status;
 import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseResponse;
 import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseResponseData;
+import com.bigtablet.bigtablethompageserver.global.common.util.RateLimiter;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
 import java.util.List;
 
 @Validated
@@ -31,10 +34,15 @@ import java.util.List;
 public class RecruitApiHandler {
 
     private final RecruitUseCase recruitUseCase;
+    private final RateLimiter rateLimiter;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public BaseResponse registerRecruit(@RequestBody @Valid final RegisterRecruitRequest request) {
+    public BaseResponse registerRecruit(
+            @RequestBody @Valid final RegisterRecruitRequest request,
+            final HttpServletRequest servletRequest
+    ) {
+        rateLimiter.check("recruit:" + RateLimiter.clientIp(servletRequest), 5, Duration.ofHours(1));
         recruitUseCase.registerRecruit(request);
         return BaseResponse.created("등록 성공");
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/api/TalentApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/api/TalentApiHandler.java
@@ -8,6 +8,8 @@ import com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request.Sea
 import com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request.SendEmailToTalentRequest;
 import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseResponse;
 import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseResponseData;
+import com.bigtablet.bigtablethompageserver.global.common.util.RateLimiter;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
 import java.util.List;
 
 @Validated
@@ -31,10 +34,15 @@ import java.util.List;
 public class TalentApiHandler {
 
     private final TalentUseCase talentUseCase;
+    private final RateLimiter rateLimiter;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public BaseResponse registerTalent(@RequestBody @Valid final RegisterTalentRequest request) {
+    public BaseResponse registerTalent(
+            @RequestBody @Valid final RegisterTalentRequest request,
+            final HttpServletRequest servletRequest
+    ) {
+        rateLimiter.check("talent:" + RateLimiter.clientIp(servletRequest), 5, Duration.ofHours(1));
         talentUseCase.registerTalent(request);
         return BaseResponse.created("등록 성공");
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/repository/redis/RedisRepository.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/repository/redis/RedisRepository.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.global.common.repository.redis;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 public interface RedisRepository {
@@ -26,5 +27,13 @@ public interface RedisRepository {
      * @param key String 삭제할 키
      */
     void delete(String key);
+
+    /**
+     * 키 값을 원자적으로 1 증가시킨다. 최초 증가(값이 1) 시 TTL을 설정한다. (고정 윈도우 카운터)
+     * @param key 카운터 키
+     * @param ttl 최초 생성 시 적용할 만료 시간
+     * @return 증가 후 카운트
+     */
+    long increment(String key, Duration ttl);
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/repository/redis/impl/RedisRepositoryImpl.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/repository/redis/impl/RedisRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.bigtablet.bigtablethompageserver.global.config.redis.RedisConfig;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Repository
@@ -43,6 +44,22 @@ public class RedisRepositoryImpl implements RedisRepository {
     @Override
     public void delete(String key) {
         redisConfig.redisTemplate().delete(key);
+    }
+
+    /**
+     * 키 값을 원자적으로 1 증가시킨다. 최초 증가(값이 1) 시 TTL을 설정한다. (고정 윈도우 카운터)
+     * @param key 카운터 키
+     * @param ttl 최초 생성 시 적용할 만료 시간
+     * @return 증가 후 카운트
+     */
+    @Override
+    public long increment(String key, Duration ttl) {
+        Long count = redisConfig.redisTemplate().opsForValue().increment(key);
+        if (count != null && count == 1L) {
+            // ponytail: INCR 후 별도 EXPIRE라 그 사이 프로세스 종료 시 키가 영구화될 수 있다. 레이트리밋엔 무해(보수적). Lua로 원자화는 처리량 필요 시.
+            redisConfig.redisTemplate().expire(key, ttl);
+        }
+        return count == null ? 0L : count;
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/RateLimiter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/RateLimiter.java
@@ -1,0 +1,43 @@
+package com.bigtablet.bigtablethompageserver.global.common.util;
+
+import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
+import com.bigtablet.bigtablethompageserver.global.exception.TooManyRequestsException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimiter {
+
+    private final RedisRepository redisRepository;
+
+    /**
+     * 고정 윈도우 카운터 기반 레이트리밋 — 윈도우 내 호출 수가 maxRequests를 넘으면 예외를 던진다.
+     * @param key 카운터 Redis 키 (호출자가 식별자 prefix 포함)
+     * @param maxRequests 윈도우당 허용 호출 수
+     * @param window 카운터 만료 윈도우
+     */
+    public void check(final String key, final int maxRequests, final Duration window) {
+        long count = redisRepository.increment(key, window);
+        if (count > maxRequests) {
+            throw TooManyRequestsException.EXCEPTION;
+        }
+    }
+
+    /**
+     * 프록시(X-Forwarded-For)를 고려한 클라이언트 IP 추출.
+     * @param request HTTP 요청
+     * @return 클라이언트 IP 문자열
+     */
+    public static String clientIp(final HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/TooManyRequestsException.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/TooManyRequestsException.java
@@ -1,0 +1,13 @@
+package com.bigtablet.bigtablethompageserver.global.exception;
+
+import com.bigtablet.bigtablethompageserver.global.exception.error.ErrorCode;
+
+public class TooManyRequestsException extends BusinessException {
+
+    public static final TooManyRequestsException EXCEPTION = new TooManyRequestsException();
+
+    private TooManyRequestsException() {
+        super(ErrorCode.TOO_MANY_REQUESTS);
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/error/ErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode implements ErrorProperty {
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/gcp/api/GcpApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/gcp/api/GcpApiHandler.java
@@ -2,7 +2,9 @@ package com.bigtablet.bigtablethompageserver.global.infra.gcp.api;
 
 import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseResponse;
 import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseResponseData;
+import com.bigtablet.bigtablethompageserver.global.common.util.RateLimiter;
 import com.bigtablet.bigtablethompageserver.global.infra.gcp.service.GcpService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.Duration;
 
 @Validated
 @RestController
@@ -27,10 +30,15 @@ import java.io.IOException;
 public class GcpApiHandler {
 
     private final GcpService gcpService;
+    private final RateLimiter rateLimiter;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public BaseResponseData<String> upload(@RequestPart @NotNull final MultipartFile multipartFile) throws IOException {
+    public BaseResponseData<String> upload(
+            @RequestPart @NotNull final MultipartFile multipartFile,
+            final HttpServletRequest servletRequest
+    ) throws IOException {
+        rateLimiter.check("gcp-upload:" + RateLimiter.clientIp(servletRequest), 20, Duration.ofHours(1));
         return BaseResponseData.created(
                 "업로드 성공",
                 gcpService.upload(multipartFile));

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/gcp/service/GcpService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/gcp/service/GcpService.java
@@ -41,12 +41,14 @@ public class GcpService {
             throw FileErrorException.EXCEPTION;
         }
         checkFileType(contentType);
+        byte[] bytes = multipartFile.getBytes();
+        checkMagicBytes(bytes, contentType);
         String uuid = UUID.randomUUID().toString();
         String imageUrl = createImageUrl(uuid);
         BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, uuid)
                 .setContentType(contentType).build();
         Storage storage = getStorage();
-        storage.create(blobInfo, multipartFile.getInputStream());
+        storage.create(blobInfo, bytes);
         return imageUrl;
     }
 
@@ -118,6 +120,39 @@ public class GcpService {
         ) {
             throw FileWrongTypeException.EXCEPTION;
         }
+    }
+
+    // 선언된 content-type과 실제 매직바이트 일치 여부 검증 (확장자/헤더 위장 업로드 차단)
+    private void checkMagicBytes(byte[] bytes, String contentType) {
+        String type = contentType.toLowerCase();
+        boolean valid;
+        if (type.equals("image/png")) {
+            valid = matchesPrefix(bytes, 0x89, 0x50, 0x4E, 0x47);
+        } else if (type.equals("image/jpg") || type.equals("image/jpeg")) {
+            valid = matchesPrefix(bytes, 0xFF, 0xD8, 0xFF);
+        } else if (type.equals("application/pdf")) {
+            valid = matchesPrefix(bytes, 0x25, 0x50, 0x44, 0x46);
+        } else if (type.equals("video/mp4")) {
+            valid = bytes.length >= 8 && bytes[4] == 'f' && bytes[5] == 't' && bytes[6] == 'y' && bytes[7] == 'p';
+        } else {
+            valid = false;
+        }
+        if (!valid) {
+            throw FileWrongTypeException.EXCEPTION;
+        }
+    }
+
+    // 바이트 배열이 주어진 시그니처(부호 없는 바이트)로 시작하는지 확인
+    private boolean matchesPrefix(byte[] bytes, int... signature) {
+        if (bytes.length < signature.length) {
+            return false;
+        }
+        for (int i = 0; i < signature.length; i++) {
+            if ((bytes[i] & 0xFF) != signature[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/test/java/com/bigtablet/bigtablethompageserver/global/common/util/RateLimiterTest.java
+++ b/src/test/java/com/bigtablet/bigtablethompageserver/global/common/util/RateLimiterTest.java
@@ -1,0 +1,59 @@
+package com.bigtablet.bigtablethompageserver.global.common.util;
+
+import com.bigtablet.bigtablethompageserver.global.common.repository.redis.RedisRepository;
+import com.bigtablet.bigtablethompageserver.global.exception.TooManyRequestsException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RateLimiterTest {
+
+    // 인메모리 카운터로 동작하는 RedisRepository 스텁 (increment만 의미 있음)
+    private static final class FakeRedis implements RedisRepository {
+
+        private final Map<String, Long> counters = new HashMap<>();
+
+        @Override
+        public <T> void save(String key, T value, int timeout, TimeUnit unit) {}
+
+        @Override
+        public <T> T getByKey(String key, Class<T> type) {
+            return null;
+        }
+
+        @Override
+        public void delete(String key) {
+            counters.remove(key);
+        }
+
+        @Override
+        public long increment(String key, Duration ttl) {
+            return counters.merge(key, 1L, Long::sum);
+        }
+
+    }
+
+    @Test
+    void allowsUpToMaxThenThrows() {
+        RateLimiter limiter = new RateLimiter(new FakeRedis());
+        assertDoesNotThrow(() -> limiter.check("k", 3, Duration.ofMinutes(1)));
+        assertDoesNotThrow(() -> limiter.check("k", 3, Duration.ofMinutes(1)));
+        assertDoesNotThrow(() -> limiter.check("k", 3, Duration.ofMinutes(1)));
+        assertThrows(TooManyRequestsException.class, () -> limiter.check("k", 3, Duration.ofMinutes(1)));
+    }
+
+    @Test
+    void separateKeysAreIndependent() {
+        RateLimiter limiter = new RateLimiter(new FakeRedis());
+        assertDoesNotThrow(() -> limiter.check("a", 1, Duration.ofMinutes(1)));
+        assertDoesNotThrow(() -> limiter.check("b", 1, Duration.ofMinutes(1)));
+        assertThrows(TooManyRequestsException.class, () -> limiter.check("a", 1, Duration.ofMinutes(1)));
+    }
+
+}


### PR DESCRIPTION
## 제목
남용 방지 레이트리밋 + OTP 무차별 대입 방어 + 업로드 콘텐츠 검증 (H2/H3/M1/M2/L2)

## 작업한 내용
- **레이트리밋 인프라**: `RedisRepository.increment(key, ttl)` (원자 INCR + 최초 1회 TTL) 추가, `RateLimiter`(고정 윈도우) + `TooManyRequestsException`(429) 신설. 단위테스트 `RateLimiterTest` 2건 통과.
- **H3 (OTP 무차별 대입)**: `verifyCode` 시도 카운터(OTP 수명 기준), 5회 초과 시 OTP 폐기 + 429. 비교를 `MessageDigest.isEqual`로 **상수시간화(L2)**.
- **M1 (OTP 발송 남용)**: `sendCode` 이메일별 30초 1회 + 1시간 10회 제한. 신규 코드 발급 시 시도 카운터 초기화.
- **M2 (공개 폼 남용)**: `POST /recruit`·`POST /talent` IP별 1시간 5회 제한.
- **H2 (업로드)**: `POST /gcp` IP별 1시간 20회 제한 + **매직바이트 검증**(png/jpg/pdf/mp4 선언 타입과 실제 시그니처 일치) — content-type 위장 차단.
- **M3 부분**: OTP 로그 이메일 마스킹(`a***@domain`).

## 전달할 추가 이슈
- 임계값(30s/10·5·20회)은 정책값 — 운영 트래픽 보고 조정 가능하도록 상수화.
- `increment`는 INCR 후 EXPIRE 비원자(레이트리밋엔 보수적 무해) — 처리량 이슈 시 Lua 원자화. 코드에 `ponytail:` 주석.
- ⚠️ **머지 순서**: `EmailVerificationService`·`GcpService`·`RedisRepository`(+impl)는 PR #143(`style/javadoc`)과 동일 파일을 건드림 — 변경 영역(주석 vs 코드)이 달라 대부분 3-way 자동 머지되나, 한쪽 머지 후 본 PR 리베이스 권장.
- 자가 리뷰만 수행 — 본 PR이 피어 리뷰·CI 게이트 대상.
