### PR TITLE
fix/pii-logging

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/usecase/WebAuthnUseCase.java
@@ -79,7 +79,7 @@ public class WebAuthnUseCase {
      * @return WebAuthnOptionsResponse 등록 옵션 JSON
      */
     public WebAuthnOptionsResponse registerStart(WebAuthnRegisterStartRequest request) {
-        log.info("[WebAuthnUseCase] registerStart - email={}", request.email());
+        log.info("[WebAuthnUseCase] registerStart - email={}", mask(request.email()));
         adminQueryService.checkEmailDomain(request.email());
         emailVerificationQueryService.checkCertified(request.email());
         String adminId = findOrCreateAdmin(request.email());
@@ -110,7 +110,7 @@ public class WebAuthnUseCase {
                     .options(optionsJson)
                     .build();
         } catch (JsonProcessingException e) {
-            log.error("[WebAuthnUseCase] registerStart 직렬화 실패 - email={}", request.email(), e);
+            log.error("[WebAuthnUseCase] registerStart 직렬화 실패 - email={}", mask(request.email()), e);
             throw WebAuthnRegistrationFailedException.EXCEPTION;
         }
     }
@@ -122,7 +122,7 @@ public class WebAuthnUseCase {
      */
     @Transactional
     public void registerFinish(WebAuthnRegisterFinishRequest request) {
-        log.info("[WebAuthnUseCase] registerFinish - email={}", request.email());
+        log.info("[WebAuthnUseCase] registerFinish - email={}", mask(request.email()));
         String redisKey = WEBAUTHN_REG_KEY_PREFIX + request.email().toLowerCase();
         String challengeJson = redisRepository.getByKey(redisKey, String.class);
         if (challengeJson == null) {
@@ -132,7 +132,7 @@ public class WebAuthnUseCase {
         try {
             challenge = objectMapper.readValue(challengeJson, WebAuthnRegisterChallenge.class);
         } catch (JsonProcessingException e) {
-            log.error("[WebAuthnUseCase] 챌린지 역직렬화 실패 - email={}", request.email(), e);
+            log.error("[WebAuthnUseCase] 챌린지 역직렬화 실패 - email={}", mask(request.email()), e);
             throw WebAuthnRegistrationFailedException.EXCEPTION;
         }
         try {
@@ -156,7 +156,7 @@ public class WebAuthnUseCase {
             redisRepository.delete(redisKey);
             log.info("[WebAuthnUseCase] registerFinish 성공 - adminId={}, credentialId={}", challenge.adminId(), credentialId);
         } catch (RegistrationFailedException | IOException e) {
-            log.error("[WebAuthnUseCase] registerFinish 실패 - email={}", request.email(), e);
+            log.error("[WebAuthnUseCase] registerFinish 실패 - email={}", mask(request.email()), e);
             throw WebAuthnRegistrationFailedException.EXCEPTION;
         }
     }
@@ -167,7 +167,7 @@ public class WebAuthnUseCase {
      * @return WebAuthnOptionsResponse 로그인 옵션 JSON
      */
     public WebAuthnOptionsResponse loginStart(WebAuthnLoginStartRequest request) {
-        log.info("[WebAuthnUseCase] loginStart - email={}", request.email());
+        log.info("[WebAuthnUseCase] loginStart - email={}", mask(request.email()));
         adminQueryService.checkEmailDomain(request.email());
         Admin admin = adminQueryService.findByEmail(request.email());
         if (!webAuthnQueryService.hasCredential(admin.id())) {
@@ -190,7 +190,7 @@ public class WebAuthnUseCase {
                     .options(optionsJson)
                     .build();
         } catch (JsonProcessingException e) {
-            log.error("[WebAuthnUseCase] loginStart 직렬화 실패 - email={}", request.email(), e);
+            log.error("[WebAuthnUseCase] loginStart 직렬화 실패 - email={}", mask(request.email()), e);
             throw WebAuthnAuthenticationFailedException.EXCEPTION;
         }
     }
@@ -202,7 +202,7 @@ public class WebAuthnUseCase {
      */
     @Transactional
     public JsonWebTokenResponse loginFinish(WebAuthnLoginFinishRequest request) {
-        log.info("[WebAuthnUseCase] loginFinish - email={}", request.email());
+        log.info("[WebAuthnUseCase] loginFinish - email={}", mask(request.email()));
         adminQueryService.checkEmailDomain(request.email());
         Admin admin = adminQueryService.findByEmail(request.email());
         String redisKey = WEBAUTHN_LOGIN_KEY_PREFIX + admin.id();
@@ -231,7 +231,7 @@ public class WebAuthnUseCase {
                     .refreshToken(jwtProvider.generateRefreshToken(admin.id()))
                     .build();
         } catch (AssertionFailedException | IOException e) {
-            log.error("[WebAuthnUseCase] loginFinish 실패 - email={}", request.email(), e);
+            log.error("[WebAuthnUseCase] loginFinish 실패 - email={}", mask(request.email()), e);
             throw WebAuthnAuthenticationFailedException.EXCEPTION;
         }
     }
@@ -242,7 +242,7 @@ public class WebAuthnUseCase {
         Admin existing = adminQueryService.findByEmailOrNull(email);
         if (existing != null) {
             if (webAuthnQueryService.hasCredential(existing.id())) {
-                log.warn("[WebAuthnUseCase] 기존 크레덴셜 보유 어드민에 대한 등록 시도 차단 - email={}", email);
+                log.warn("[WebAuthnUseCase] 기존 크레덴셜 보유 어드민에 대한 등록 시도 차단 - email={}", mask(email));
                 throw CredentialAlreadyRegisteredException.EXCEPTION;
             }
             return existing.id();
@@ -250,7 +250,7 @@ public class WebAuthnUseCase {
         try {
             return adminService.save(email);
         } catch (DataIntegrityViolationException ex) {
-            log.warn("[WebAuthnUseCase] 동시 요청으로 어드민 중복 생성 시도 - email={}", email);
+            log.warn("[WebAuthnUseCase] 동시 요청으로 어드민 중복 생성 시도 - email={}", mask(email));
             Admin retried = adminQueryService.findByEmailOrNull(email);
             if (retried == null) {
                 throw ex;
@@ -260,6 +260,18 @@ public class WebAuthnUseCase {
             }
             return retried.id();
         }
+    }
+
+    // 이메일 로컬파트를 마스킹하여 로그 PII 노출을 줄인다 (예: a***@bigtablet.com)
+    private String mask(String email) {
+        if (email == null) {
+            return "null";
+        }
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return "***";
+        }
+        return email.charAt(0) + "***" + email.substring(at);
     }
 
     // Redis 저장용 챌린지 record

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
@@ -28,7 +28,6 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
         String method = request.getMethod();
         String rawUri = request.getRequestURI();
         String decodedUri = UriUtils.decode(rawUri, StandardCharsets.UTF_8);
-        String query = request.getQueryString();
         String ua = Optional.ofNullable(request.getHeader("User-Agent")).orElse("-");
         try {
             chain.doFilter(request, response);
@@ -36,8 +35,8 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             int status = response.getStatus();
 
             org.slf4j.LoggerFactory.getLogger(RequestLoggingFilter.class).info(
-                    "traceId={} ip={} method={} uri={}{} status={} ua={}",
-                    traceId, clientIp, method, decodedUri, (query != null ? "?" + query : ""), status, ua
+                    "traceId={} ip={} method={} uri={} status={} ua={}",
+                    traceId, clientIp, method, decodedUri, status, ua
             );
             MDC.remove("traceId");
         }


### PR DESCRIPTION
## 제목
로그 PII 노출 완화 (M3)

## 작업한 내용
- `WebAuthnUseCase` 어드민 이메일 로그 11곳 마스킹(`a***@domain`) — 비-로그 사용처(checkEmailDomain/findByEmail/UserIdentity)는 원본 유지.
- `RequestLoggingFilter`에서 쿼리스트링 로깅 제거(공개 엔드포인트의 쿼리 파라미터로 PII/토큰 유출 가능) + 미사용 `query` 변수 제거.
- `compileJava` 통과.

## 전달할 추가 이슈
- EmailVerificationService 이메일 로그 마스킹은 `feat/abuse-rate-limiting`(PR #147)에 포함.
- ⚠️ **머지 순서**: `RequestLoggingFilter`는 PR #144(`style/global-method-body`)와, `WebAuthnUseCase`는 PR #143(`style/javadoc`)와 동일 파일 — 영역이 달라 대부분 3-way 자동 머지되나 선행 머지 후 리베이스 권장.
- 자가 리뷰만 수행 — 본 PR이 피어 리뷰·CI 게이트 대상.
