### PR TITLE
fix/recruit-mail-after-commit

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailEventListener.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailEventListener.java
@@ -1,0 +1,25 @@
+package com.bigtablet.bigtablethompageserver.domain.recruit.application.event;
+
+import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class RecruitMailEventListener {
+
+    private final EmailService emailService;
+
+    /**
+     * 상태 변경 트랜잭션이 커밋된 뒤에만 채용 메일을 발송한다(롤백 시 오발송 방지).
+     * EmailService.sendRecruit 자체가 @Async 라 발송은 별도 스레드로 위임된다.
+     * @param event 발송할 메일 정보
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(final RecruitMailRequestedEvent event) {
+        emailService.sendRecruit(event.to(), event.subject(), event.content());
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailEventListener.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailEventListener.java
@@ -15,9 +15,10 @@ public class RecruitMailEventListener {
     /**
      * 상태 변경 트랜잭션이 커밋된 뒤에만 채용 메일을 발송한다(롤백 시 오발송 방지).
      * EmailService.sendRecruit 자체가 @Async 라 발송은 별도 스레드로 위임된다.
+     * fallbackExecution=true: 트랜잭션이 없는 컨텍스트(테스트 등)에서 호출돼도 이벤트가 조용히 무시되지 않고 즉시 발송된다(롤백 대상이 없으므로 안전).
      * @param event 발송할 메일 정보
      */
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void handle(final RecruitMailRequestedEvent event) {
         emailService.sendRecruit(event.to(), event.subject(), event.content());
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailRequestedEvent.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailRequestedEvent.java
@@ -1,0 +1,11 @@
+package com.bigtablet.bigtablethompageserver.domain.recruit.application.event;
+
+/**
+ * 채용 상태 변경 트랜잭션 커밋 후 발송할 메일 정보를 담는 도메인 이벤트.
+ */
+public record RecruitMailRequestedEvent(
+        String to,
+        String subject,
+        String content
+) {
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -3,6 +3,7 @@ package com.bigtablet.bigtablethompageserver.domain.recruit.application.usecase;
 import com.bigtablet.bigtablethompageserver.domain.job.application.query.JobQueryService;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.model.Job;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.constant.RecruitMailSubject;
+import com.bigtablet.bigtablethompageserver.domain.recruit.application.event.RecruitMailRequestedEvent;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.query.RecruitQueryService;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.response.RecruitResponse;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.service.RecruitService;
@@ -15,7 +16,9 @@ import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailServ
 import com.bigtablet.bigtablethompageserver.global.infra.slack.service.SlackNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,6 +34,7 @@ public class RecruitUseCase {
     private final JobQueryService jobQueryService;
     private final MailTemplateRenderer mailTemplateRenderer;
     private final SlackNotifier slackNotifier;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 채용 지원 등록 (지원 접수 확인 이메일 + 슬랙 알림 발송)
@@ -93,52 +97,53 @@ public class RecruitUseCase {
      * @param status 변경할 지원서 상태
      * @param idx 지원서 식별자
      */
+    @Transactional
     public void updateStatus(Status status, Long idx) {
         log.info("[RecruitUseCase] updateStatus - idx={}, status={}", idx, status);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderRecruitEmail(recruit.name(), status);
-        // 상태 변경(recruitService 자체 @Transactional)이 커밋된 뒤 메일 발송 — UseCase를 트랜잭션으로 묶으면 롤백 시 오발송되므로 묶지 않는다
         recruitService.editStatus(status, idx);
-        emailService.sendRecruit(
+        // 메일은 RecruitMailEventListener가 AFTER_COMMIT 에서 발송 — 트랜잭션 롤백 시 오발송 방지
+        eventPublisher.publishEvent(new RecruitMailRequestedEvent(
                 recruit.email(),
                 RecruitMailSubject.interviewGuide(recruit.name()),
                 content
-        );
+        ));
     }
 
     /**
      * 지원자 최종 합격 처리 (합격 이메일 발송)
      * @param idx 지원서 식별자
      */
+    @Transactional
     public void acceptRecruit(Long idx) {
         log.info("[RecruitUseCase] acceptRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderAcceptEmail(recruit.name());
         recruitQueryService.checkStatus(recruit);
-        // 합격 처리(recruitService 자체 @Transactional) 커밋 뒤 메일 발송 — 롤백 시 오발송 방지
         recruitService.accept(recruit.idx());
-        emailService.sendRecruit(
+        eventPublisher.publishEvent(new RecruitMailRequestedEvent(
                 recruit.email(),
                 RecruitMailSubject.finalResult(recruit.name()),
                 content
-        );
+        ));
     }
 
     /**
      * 지원자 최종 불합격 처리 (불합격 이메일 발송)
      * @param idx 지원서 식별자
      */
+    @Transactional
     public void rejectRecruit(Long idx) {
         log.info("[RecruitUseCase] rejectRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderRejectEmail(recruit.name());
-        // 불합격 처리(recruitService 자체 @Transactional) 커밋 뒤 메일 발송 — 롤백 시 오발송 방지
         recruitService.reject(recruit.idx());
-        emailService.sendRecruit(
+        eventPublisher.publishEvent(new RecruitMailRequestedEvent(
                 recruit.email(),
                 RecruitMailSubject.finalResult(recruit.name()),
                 content
-        );
+        ));
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -16,7 +16,6 @@ import com.bigtablet.bigtablethompageserver.global.infra.slack.service.SlackNoti
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -94,11 +93,11 @@ public class RecruitUseCase {
      * @param status 변경할 지원서 상태
      * @param idx 지원서 식별자
      */
-    @Transactional
     public void updateStatus(Status status, Long idx) {
         log.info("[RecruitUseCase] updateStatus - idx={}, status={}", idx, status);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderRecruitEmail(recruit.name(), status);
+        // 상태 변경(recruitService 자체 @Transactional)이 커밋된 뒤 메일 발송 — UseCase를 트랜잭션으로 묶으면 롤백 시 오발송되므로 묶지 않는다
         recruitService.editStatus(status, idx);
         emailService.sendRecruit(
                 recruit.email(),
@@ -111,12 +110,12 @@ public class RecruitUseCase {
      * 지원자 최종 합격 처리 (합격 이메일 발송)
      * @param idx 지원서 식별자
      */
-    @Transactional
     public void acceptRecruit(Long idx) {
         log.info("[RecruitUseCase] acceptRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderAcceptEmail(recruit.name());
         recruitQueryService.checkStatus(recruit);
+        // 합격 처리(recruitService 자체 @Transactional) 커밋 뒤 메일 발송 — 롤백 시 오발송 방지
         recruitService.accept(recruit.idx());
         emailService.sendRecruit(
                 recruit.email(),
@@ -129,11 +128,11 @@ public class RecruitUseCase {
      * 지원자 최종 불합격 처리 (불합격 이메일 발송)
      * @param idx 지원서 식별자
      */
-    @Transactional
     public void rejectRecruit(Long idx) {
         log.info("[RecruitUseCase] rejectRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderRejectEmail(recruit.name());
+        // 불합격 처리(recruitService 자체 @Transactional) 커밋 뒤 메일 발송 — 롤백 시 오발송 방지
         recruitService.reject(recruit.idx());
         emailService.sendRecruit(
                 recruit.email(),


### PR DESCRIPTION
## 제목
채용 상태변경 메일을 트랜잭션 커밋 후 발송 (적대적 리뷰 MEDIUM)

## 작업한 내용
- `RecruitUseCase`의 `updateStatus`/`acceptRecruit`/`rejectRecruit`에서 `@Transactional` 제거. 기존엔 `@Transactional` 메서드 내부에서 `@Async`인 `emailService.sendRecruit`가 호출돼, 이후 트랜잭션이 롤백되면 **영속되지 않은 상태 전이에 대한 합격/면접/불합격 메일이 발송**되는 정합성 결함이 있었음.
- `RecruitService.editStatus/accept/reject`는 각자 `@Transactional`(REQUIRED)이라 메서드 반환 시 자체 커밋되므로, UseCase에서 트랜잭션을 벗기면 **상태 변경 커밋 후에만 메일이 발송**됨. 단일 write라 UseCase 레벨 원자성 불필요.
- 회귀 방지용 주석 추가. `compileJava` 통과.

## 전달할 추가 이슈
- 자가 리뷰만 수행 — 본 PR이 피어 리뷰·CI 게이트 대상.
