### PR TITLE
fix/otp-ratelimit-review

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
@@ -65,12 +65,15 @@ public class EmailVerificationService {
     public void verifyCode(String email, String authCode) {
         log.info("[EmailVerificationService] verifyCode - email={}", mask(email));
         String normalized = email.toLowerCase();
-        // 분산 무차별 대입(다수 IP) 방어: per-IP(핸들러)에 더해 이메일별 검증 시도를 OTP 수명 동안 제한.
-        // OTP를 삭제하지 않는 비파괴 방식이라 기존의 락아웃-삭제 DoS는 없고, 6자리 OTP가 1윈도우당 최대 5회로 묶여 계정 탈취를 차단한다.
-        rateLimiter.check("otp-verify-email:" + normalized, 5, adminAuthProperties.otpTtl());
         String savedCode = redisRepository.getByKey(OTP_KEY_PREFIX + normalized, String.class);
+        // 활성 OTP가 없으면 레이트리밋 카운터를 증가시키지 않는다 — 미발급 이메일에 /verify 를 반복해 선제 락아웃하는 DoS 방지
+        if (savedCode == null) {
+            throw EmailCodeMismatchException.EXCEPTION;
+        }
+        // 분산 무차별 대입(다수 IP) 방어: 활성 OTP 수명 동안 이메일별 검증 시도를 비파괴(OTP 미삭제)로 제한 — 1윈도우당 최대 5회
+        rateLimiter.check("otp-verify-email:" + normalized, 5, adminAuthProperties.otpTtl());
         // 상수 시간 비교로 타이밍 사이드채널 차단
-        if (savedCode == null || authCode == null
+        if (authCode == null
                 || !MessageDigest.isEqual(savedCode.getBytes(StandardCharsets.UTF_8), authCode.getBytes(StandardCharsets.UTF_8))) {
             throw EmailCodeMismatchException.EXCEPTION;
         }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/application/service/EmailVerificationService.java
@@ -65,8 +65,9 @@ public class EmailVerificationService {
     public void verifyCode(String email, String authCode) {
         log.info("[EmailVerificationService] verifyCode - email={}", mask(email));
         String normalized = email.toLowerCase();
-        // 무차별 대입은 엔드포인트의 per-IP 레이트리밋(EmailVerificationApiHandler)으로 차단한다.
-        // 과거의 per-email 시도 카운터는 공격자가 피해자의 활성 OTP를 삭제·잠금하는 DoS 벡터라 제거했다.
+        // 분산 무차별 대입(다수 IP) 방어: per-IP(핸들러)에 더해 이메일별 검증 시도를 OTP 수명 동안 제한.
+        // OTP를 삭제하지 않는 비파괴 방식이라 기존의 락아웃-삭제 DoS는 없고, 6자리 OTP가 1윈도우당 최대 5회로 묶여 계정 탈취를 차단한다.
+        rateLimiter.check("otp-verify-email:" + normalized, 5, adminAuthProperties.otpTtl());
         String savedCode = redisRepository.getByKey(OTP_KEY_PREFIX + normalized, String.class);
         // 상수 시간 비교로 타이밍 사이드채널 차단
         if (savedCode == null || authCode == null

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/client/api/EmailVerificationApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/admin/client/api/EmailVerificationApiHandler.java
@@ -40,8 +40,9 @@ public class EmailVerificationApiHandler {
             @RequestBody @Valid final EmailSendRequest request,
             final HttpServletRequest servletRequest
     ) {
-        rateLimiter.check("otp-send-ip:" + RateLimiter.clientIp(servletRequest), 5, Duration.ofHours(1));
+        // 도메인 검증을 먼저 — 허용되지 않은 요청이 IP 레이트리밋 카운터를 소모하지 않도록
         adminQueryService.checkEmailDomain(request.email());
+        rateLimiter.check("otp-send-ip:" + RateLimiter.clientIp(servletRequest), 5, Duration.ofHours(1));
         emailVerificationService.sendCode(request.email());
         return BaseResponse.ok("OTP 발송 성공");
     }
@@ -57,8 +58,9 @@ public class EmailVerificationApiHandler {
             @RequestBody @Valid final EmailVerifyRequest request,
             final HttpServletRequest servletRequest
     ) {
-        rateLimiter.check("otp-verify-ip:" + RateLimiter.clientIp(servletRequest), 10, Duration.ofHours(1));
+        // 도메인 검증을 먼저 — 허용되지 않은 요청이 IP 레이트리밋 카운터를 소모하지 않도록
         adminQueryService.checkEmailDomain(request.email());
+        rateLimiter.check("otp-verify-ip:" + RateLimiter.clientIp(servletRequest), 10, Duration.ofHours(1));
         emailVerificationService.verifyCode(request.email(), request.code());
         return BaseResponse.ok("이메일 인증 성공");
     }


### PR DESCRIPTION
## 제목
[#150 리뷰 반영] 도메인 검증 선행 + 이메일별 OTP 검증 제한(비파괴)

> base: `fix/otp-verify-ratelimit` (PR #150) — 리뷰 스택 PR

## 작업한 내용 (gemini 리뷰 반영)
- **(HIGH) 분산 무차별 대입 방어** [comment 3464037536]: per-IP만으론 다수 IP로 6자리 OTP 분산 대입이 가능하다는 지적 반영. 이메일별 검증 제한 `rateLimiter.check("otp-verify-email:"+email, 5, otpTtl)` 추가 → 1 OTP 윈도우당 이메일별 최대 5회로 묶어 탈취 차단. **OTP를 삭제하지 않는 비파괴 방식**이라 기존(삭제+락아웃)의 DoS는 없음. per-IP(핸들러) + per-email(서비스) + 발송 제한의 다층 방어.
- **(MEDIUM ×2) 검증 순서** [3464037539, 3464037545]: `/send`·`/verify` 모두 `checkEmailDomain`을 레이트리밋보다 **먼저** 수행 → 허용되지 않은 도메인 요청이 IP 카운터를 소모하지 않도록.
- `compileJava` + RateLimiterTest 통과.

## 비고
- 이 PR은 #150 브랜치를 base로 한 스택 PR입니다. #150 머지 전 함께 정리하거나, #150에 먼저 머지 후 develop으로 올리면 됩니다.
