### PR TITLE
fix/recruit-mail-event

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailEventListener.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailEventListener.java
@@ -1,0 +1,25 @@
+package com.bigtablet.bigtablethompageserver.domain.recruit.application.event;
+
+import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class RecruitMailEventListener {
+
+    private final EmailService emailService;
+
+    /**
+     * 상태 변경 트랜잭션이 커밋된 뒤에만 채용 메일을 발송한다(롤백 시 오발송 방지).
+     * EmailService.sendRecruit 자체가 @Async 라 발송은 별도 스레드로 위임된다.
+     * @param event 발송할 메일 정보
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(final RecruitMailRequestedEvent event) {
+        emailService.sendRecruit(event.to(), event.subject(), event.content());
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailEventListener.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailEventListener.java
@@ -15,9 +15,10 @@ public class RecruitMailEventListener {
     /**
      * 상태 변경 트랜잭션이 커밋된 뒤에만 채용 메일을 발송한다(롤백 시 오발송 방지).
      * EmailService.sendRecruit 자체가 @Async 라 발송은 별도 스레드로 위임된다.
+     * fallbackExecution=true: 트랜잭션이 없는 컨텍스트(테스트 등)에서 호출돼도 이벤트가 조용히 무시되지 않고 즉시 발송된다(롤백 대상이 없으므로 안전).
      * @param event 발송할 메일 정보
      */
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void handle(final RecruitMailRequestedEvent event) {
         emailService.sendRecruit(event.to(), event.subject(), event.content());
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailRequestedEvent.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/event/RecruitMailRequestedEvent.java
@@ -1,0 +1,11 @@
+package com.bigtablet.bigtablethompageserver.domain.recruit.application.event;
+
+/**
+ * 채용 상태 변경 트랜잭션 커밋 후 발송할 메일 정보를 담는 도메인 이벤트.
+ */
+public record RecruitMailRequestedEvent(
+        String to,
+        String subject,
+        String content
+) {
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -3,6 +3,7 @@ package com.bigtablet.bigtablethompageserver.domain.recruit.application.usecase;
 import com.bigtablet.bigtablethompageserver.domain.job.application.query.JobQueryService;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.model.Job;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.constant.RecruitMailSubject;
+import com.bigtablet.bigtablethompageserver.domain.recruit.application.event.RecruitMailRequestedEvent;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.query.RecruitQueryService;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.response.RecruitResponse;
 import com.bigtablet.bigtablethompageserver.domain.recruit.application.service.RecruitService;
@@ -15,7 +16,9 @@ import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailServ
 import com.bigtablet.bigtablethompageserver.global.infra.slack.service.SlackNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,6 +34,7 @@ public class RecruitUseCase {
     private final JobQueryService jobQueryService;
     private final MailTemplateRenderer mailTemplateRenderer;
     private final SlackNotifier slackNotifier;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 채용 지원 등록 (지원 접수 확인 이메일 + 슬랙 알림 발송)
@@ -93,52 +97,53 @@ public class RecruitUseCase {
      * @param status 변경할 지원서 상태
      * @param idx 지원서 식별자
      */
+    @Transactional
     public void updateStatus(Status status, Long idx) {
         log.info("[RecruitUseCase] updateStatus - idx={}, status={}", idx, status);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderRecruitEmail(recruit.name(), status);
-        // 상태 변경(recruitService 자체 @Transactional)이 커밋된 뒤 메일 발송 — UseCase를 트랜잭션으로 묶으면 롤백 시 오발송되므로 묶지 않는다
         recruitService.editStatus(status, idx);
-        emailService.sendRecruit(
+        // 메일은 RecruitMailEventListener가 AFTER_COMMIT 에서 발송 — 트랜잭션 롤백 시 오발송 방지
+        eventPublisher.publishEvent(new RecruitMailRequestedEvent(
                 recruit.email(),
                 RecruitMailSubject.interviewGuide(recruit.name()),
                 content
-        );
+        ));
     }
 
     /**
      * 지원자 최종 합격 처리 (합격 이메일 발송)
      * @param idx 지원서 식별자
      */
+    @Transactional
     public void acceptRecruit(Long idx) {
         log.info("[RecruitUseCase] acceptRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderAcceptEmail(recruit.name());
         recruitQueryService.checkStatus(recruit);
-        // 합격 처리(recruitService 자체 @Transactional) 커밋 뒤 메일 발송 — 롤백 시 오발송 방지
         recruitService.accept(recruit.idx());
-        emailService.sendRecruit(
+        eventPublisher.publishEvent(new RecruitMailRequestedEvent(
                 recruit.email(),
                 RecruitMailSubject.finalResult(recruit.name()),
                 content
-        );
+        ));
     }
 
     /**
      * 지원자 최종 불합격 처리 (불합격 이메일 발송)
      * @param idx 지원서 식별자
      */
+    @Transactional
     public void rejectRecruit(Long idx) {
         log.info("[RecruitUseCase] rejectRecruit - idx={}", idx);
         Recruit recruit = recruitQueryService.find(idx);
         String content = mailTemplateRenderer.renderRejectEmail(recruit.name());
-        // 불합격 처리(recruitService 자체 @Transactional) 커밋 뒤 메일 발송 — 롤백 시 오발송 방지
         recruitService.reject(recruit.idx());
-        emailService.sendRecruit(
+        eventPublisher.publishEvent(new RecruitMailRequestedEvent(
                 recruit.email(),
                 RecruitMailSubject.finalResult(recruit.name()),
                 content
-        );
+        ));
     }
 
 }


### PR DESCRIPTION
## 제목
[#151 리뷰 반영] 채용 메일을 AFTER_COMMIT 트랜잭션 이벤트로 발송

> base: `fix/recruit-mail-after-commit` (PR #151) — 리뷰 스택 PR

## 작업한 내용 (gemini 리뷰 반영, comment 3464049129)
`@Transactional` 제거 방식의 한계(원자성·커넥션 오버헤드·전파 시 재발) 지적을 반영해, 권장안(Spring Application Event + `@TransactionalEventListener`)으로 전환:
- `RecruitMailRequestedEvent`(record) + `RecruitMailEventListener`(`@TransactionalEventListener(AFTER_COMMIT)`) 신설.
- `updateStatus`/`acceptRecruit`/`rejectRecruit`에 **`@Transactional` 복원** + 직접 메일 발송 대신 `eventPublisher.publishEvent(...)`. 커밋 성공 시에만 리스너가 메일 발송 → 롤백 시 오발송 방지하면서 UseCase 트랜잭션 경계 유지.
- 리스너는 `@Async` 없이 두고 `EmailService.sendRecruit`(자체 `@Async`)가 발송을 위임 — 이중 디스패치 회피.
- `registerRecruit`는 비-트랜잭션(save 커밋 후 발송)이라 직접 발송 유지.
- `compileJava` + RateLimiterTest 통과.

## 비고
- #151 브랜치를 base로 한 스택 PR.
