### PR TITLE
config/coderabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,10 +18,8 @@ reviews:
   path_instructions:
     - path: "src/main/java/**/*.java"
       instructions: >-
-        이 저장소에 커밋된 컨벤션 문서를 리뷰 기준으로 삼아라:
-        CLAUDE.md (컨벤션 인덱스 + Prohibited 목록 + 패키지 구조),
-        .claude/architecture.md, .claude/layer-conventions.md,
-        .claude/java-code-style.md, .claude/infrastructure.md, .claude/git-convention.md.
+        이 백엔드의 컨벤션 위반을 리뷰 기준으로 삼아라.
+        (컨벤션 원문 CLAUDE.md / .claude/*.md 는 이 저장소에서 .gitignore 대상이라 커밋돼 있지 않으니, 아래 인라인 핵심 규칙만으로 판단하라.)
         아래 핵심 규칙 위반은 반드시 지적하라.
         (1) 레이어 흐름 ApiHandler→UseCase→Service/QueryService→Repository.
         ApiHandler 가 Service/QueryService/Repository 를 직접 의존하면 안 됨(UseCase 경유).

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,42 @@
+# CodeRabbit 설정 — https://docs.coderabbit.ai/guides/configure-coderabbit
+# 리뷰 언어: 한국어
+language: ko-KR
+
+reviews:
+  # chill = 신호 위주(노이즈↓). 더 깐깐하게 보려면 assertive 로 변경.
+  profile: chill
+  high_level_summary: true
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    # 모든 base 브랜치의 PR 을 자동 리뷰한다 (정규식 ".*" — 전체 매칭).
+    # main/develop/release 등 어떤 브랜치를 타깃하든 CodeRabbit 이 자동 리뷰한다.
+    base_branches:
+      - ".*"
+  # 경로별 리뷰 지침 — 저장소에 커밋된 컨벤션 문서를 기준으로 삼게 한다.
+  path_instructions:
+    - path: "src/main/java/**/*.java"
+      instructions: >-
+        이 저장소에 커밋된 컨벤션 문서를 리뷰 기준으로 삼아라:
+        CLAUDE.md (컨벤션 인덱스 + Prohibited 목록 + 패키지 구조),
+        .claude/architecture.md, .claude/layer-conventions.md,
+        .claude/java-code-style.md, .claude/infrastructure.md, .claude/git-convention.md.
+        아래 핵심 규칙 위반은 반드시 지적하라.
+        (1) 레이어 흐름 ApiHandler→UseCase→Service/QueryService→Repository.
+        ApiHandler 가 Service/QueryService/Repository 를 직접 의존하면 안 됨(UseCase 경유).
+        (2) Service=command 전용(save/edit/delete), QueryService=query 전용(find/exists/check).
+        Service 에 query 메서드, QueryService 에 command 메서드가 있으면 지적.
+        (3) Service 는 한 도메인의 Repository 만 주입. Service↔Service 직접 주입 금지(UseCase 로 조합).
+        QueryService 는 한 도메인의 JpaRepository 와/또는 QueryRepository 만 주입(타 도메인 레포 금지).
+        (4) Service 레이어에서 BaseResponse / Request·Response DTO 사용 금지.
+        (5) 도메인 model 에 JPA 어노테이션 금지, Entity 에 불필요한 @Setter 금지, Entity mutator 는 edit{Field} 네이밍.
+        (6) wildcard import, var 타입추론, C-style 배열(String[] 가 아닌 String x[]), 메서드 내부 빈 줄 금지.
+        (7) import 그룹/정렬(java→javax→org→com, static 마지막, 그룹 내 알파벳순),
+        어노테이션은 길이순(짧은→긴) 정렬, Javadoc 은 public/protected API 에만(구현 주석엔 //).
+    - path: "src/test/**/*.java"
+      instructions: >-
+        테스트는 동작 검증 중심으로 보고, 위 컨벤션 중 스타일 규칙은 완화해서 적용하라.
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## 제목
CodeRabbit 설정 추가 (`.coderabbit.yaml`) — 자동 한국어 컨벤션 리뷰

## 작업한 내용
- `bigtablet-notiiv-server`의 `.coderabbit.yaml`을 **그대로** 추가(org 표준 유지, byte-identical).
- 한국어 리뷰(`ko-KR`), `chill` 프로파일, 자동 리뷰(모든 base 브랜치 `.*`), 경로별 지침(`src/main/java` 컨벤션 7대 규칙 / `src/test`는 완화).

## ⚠️ 이 레포 특이사항 (확인 필요)
`path_instructions`가 `CLAUDE.md` 및 `.claude/*.md`를 리뷰 기준 문서로 가리키는데, **이 레포에선 두 경로가 `.gitignore` 대상**이라 GitHub에 커밋되어 있지 않습니다(notiiv는 커밋돼 있는 듯). 따라서 CodeRabbit은 그 파일들을 읽지 못하고, **지침에 인라인으로 박힌 핵심 규칙 (1)~(7)** 을 기준으로 리뷰합니다(리뷰는 정상 동작, 다만 전체 문서 grounding은 안 됨).

→ 전체 문서까지 CodeRabbit이 참고하게 하려면 `CLAUDE.md`·`.claude/`를 gitignore에서 제외(커밋)해야 합니다. 원하시면 별도로 처리하겠습니다. 지금은 인라인 규칙만으로도 컨벤션 위반 리뷰는 됩니다.
