### PR TITLE
config/track-convention-docs

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -1,0 +1,332 @@
+# Architecture
+
+## Layer Structure
+```
+API Handler → UseCase → Service / QueryService → Repository
+     ↓           ↓          ↓           ↓             ↓
+  Request    Response   Domain      Domain         Entity
+    DTO        DTO      Object      Object         (JPA)
+```
+
+## Layer Responsibilities
+
+### 1. API Handler (Controller)
+- Handles HTTP request/response
+- Passes Request DTO to UseCase
+- Returns Response DTO to client
+
+### 2. UseCase
+- Orchestrates business use cases (Facade pattern)
+- Decomposes Request DTO into parameters and calls Service/QueryService
+- Converts Domain objects into Response DTOs
+- **Only layer where multiple Services can be combined**
+- **Only layer where cross-domain orchestration is allowed** — any interaction between two domains (see the Domain Interaction Map below) is expressed here by injecting the other domain's `Service`/`QueryService`, never by Service-to-Service injection
+
+### 3. Service (Command)
+- Performs **command** operations only: save, edit, delete
+- Returns Domain objects or void
+- **Does NOT receive or return Request/Response DTOs**
+- **Injects only ONE Repository** (no service-to-service dependency)
+- Converts Entity ↔ Domain objects
+
+### 4. QueryService (Query)
+- Performs **query** operations only: find, check, exists
+- Returns Domain objects
+- **Injects only ONE domain's repositories** — its `JpaRepository` and/or `QueryRepository` may be injected together (JpaRepository for derived single-entity finders, QueryRepository for dynamic/paged/projection queries); does NOT inject other domains' repositories
+- Follows CQS (Command Query Separation) principle
+- **Location**: `application/query/{Domain}QueryService.java`
+
+### 5. Repository
+- Database access
+- Returns Entity
+
+---
+
+## Object Types
+
+### Request DTO
+- **Location**: `domain/{domain}/client/dto/request/`
+- **Role**: Transfers API request data
+- **Usage**: API Handler → UseCase
+
+### Response DTO
+- **Location**: `domain/{domain}/application/response/`
+- **Role**: Transfers API response data
+- **Usage**: UseCase → API Handler
+- **Conversion**: `Response.of(Domain)`
+
+### Domain Object
+- **Location**: `domain/{domain}/domain/model/`
+- **Role**: Pure business domain concept
+- **Characteristic**: No JPA annotations
+- **Usage**: Service ↔ UseCase
+- **Conversion**: `Domain.of(Entity)`
+
+### Entity
+- **Location**: `domain/{domain}/domain/entity/`
+- **Role**: Database mapping
+- **Characteristic**: Contains JPA annotations
+- **Usage**: Repository ↔ Service
+
+---
+
+## Data Flow
+
+### Read Operations (via QueryService)
+```
+1. API Handler: Receives Request
+2. UseCase: Decomposes Request into parameters, calls QueryService
+3. QueryService: Queries Entity from Repository
+4. QueryService: Converts Entity → Domain object
+5. QueryService: Returns Domain object
+6. UseCase: Converts Domain → Response DTO
+7. API Handler: Returns Response
+```
+
+### Write Operations (via Service)
+```
+1. API Handler: Receives Request
+2. UseCase: Decomposes Request into parameters, calls Service
+3. Service: Converts parameters → Entity
+4. Service: Saves/edits Entity via Repository
+5. Service: Converts Entity → Domain object (if needed)
+6. Service: Returns Domain object or void
+7. UseCase: Converts Domain → Response DTO (if needed)
+8. API Handler: Returns Response
+```
+
+---
+
+## Code Examples
+
+### Domain Object
+```java
+// domain/asset/domain/model/Asset.java
+@Builder
+public record Asset(
+    Long id,
+    AssetType assetType,
+    String itemName
+) {
+    public static Asset of(AssetEntity entity) {
+        return Asset.builder()
+            .id(entity.getId())
+            .assetType(entity.getAssetType())
+            .itemName(entity.getItemName())
+            .build();
+    }
+}
+```
+
+### Service (Command only)
+```java
+// domain/asset/application/service/AssetService.java
+@Service
+@RequiredArgsConstructor
+public class AssetService {
+
+    private final AssetJpaRepository repository;
+
+    @Transactional
+    public void save(AssetType assetType, String itemName) {
+        AssetEntity entity = AssetEntity.builder()
+            .assetType(assetType)
+            .itemName(itemName)
+            .build();
+        repository.save(entity);
+    }
+
+    @Transactional
+    public void edit(Long id, AssetType assetType, String itemName) {
+        AssetEntity entity = repository.findById(id)
+            .orElseThrow(() -> AssetNotFoundException.EXCEPTION);
+        entity.editAsset(assetType, itemName);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        AssetEntity entity = repository.findById(id)
+            .orElseThrow(() -> AssetNotFoundException.EXCEPTION);
+        entity.delete();
+        repository.save(entity);
+    }
+
+}
+```
+
+### QueryService (Query only)
+```java
+// domain/asset/application/query/AssetQueryService.java
+@Service
+@RequiredArgsConstructor
+public class AssetQueryService {
+
+    private final AssetJpaRepository repository;
+
+    public Asset find(Long id) {
+        AssetEntity entity = repository.findById(id)
+            .orElseThrow(() -> AssetNotFoundException.EXCEPTION);
+        return Asset.of(entity);
+    }
+
+    public List<Asset> findAll() {
+        return repository.findAll().stream()
+            .map(Asset::of)
+            .toList();
+    }
+
+}
+```
+
+### UseCase
+```java
+// domain/asset/application/usecase/AssetUseCase.java
+@Component
+@RequiredArgsConstructor
+public class AssetUseCase {
+
+    private final AssetService assetService;
+    private final AssetQueryService assetQueryService;
+
+    public void register(CreateAssetRequest request) {
+        assetService.save(
+            request.assetType(),
+            request.itemName()
+        );
+    }
+
+    public AssetResponse getById(Long assetId) {
+        Asset asset = assetQueryService.find(assetId);
+        return AssetResponse.of(asset);
+    }
+
+    public List<AssetResponse> getAll() {
+        List<Asset> assets = assetQueryService.findAll();
+        return assets.stream()
+            .map(AssetResponse::of)
+            .toList();
+    }
+
+    public void update(UpdateAssetRequest request) {
+        assetService.edit(
+            request.assetId(),
+            request.assetType(),
+            request.itemName()
+        );
+    }
+
+    public void delete(Long assetId) {
+        assetService.delete(assetId);
+    }
+
+}
+```
+
+### Response DTO
+```java
+// domain/asset/application/response/AssetResponse.java
+@Builder
+public record AssetResponse(
+    Long id,
+    AssetType assetType,
+    String itemName
+) {
+    public static AssetResponse of(Asset asset) {
+        return AssetResponse.builder()
+            .id(asset.id())
+            .assetType(asset.assetType())
+            .itemName(asset.itemName())
+            .build();
+    }
+}
+```
+
+---
+
+# Product Architecture
+
+> The sections above define the **layered-architecture conventions** every domain must follow. The sections below describe the **product** those conventions implement: its domains, how they interact, the key flows, and the infrastructure they depend on. The `asset` example above is purely illustrative — the real domains are catalogued below.
+
+## Product Overview
+
+`bigtablet-homepage-server` is the Java 21 / Spring Boot backend for the **Bigtablet corporate homepage**. It exposes public, bilingual (KR/EN) site content — **blog** posts, **news** items, and **job** postings — plus two public visitor actions: submitting a **recruit** (job application) and registering in the **talent** pool. Everything else is a **MASTER-admin back-office**: admins authenticate through Redis-backed email verification and **WebAuthn/FIDO2 passkeys**, receive a stateless **JWT**, and manage content. Recruitment events fan out **email** (SMTP + Thymeleaf, KR/EN templates) and **Slack** notifications; uploaded images live in **Google Cloud Storage**; list/search reads use **QueryDSL** paging; a daily scheduler expires ended job postings.
+
+## Domain Catalog
+
+The codebase is organized into **6 business domains**, plus the cross-cutting **global/security** layer and a **global infra / config / common** layer. Each domain follows the layer conventions above; cross-domain calls happen **only in the UseCase layer**.
+
+| Domain | Purpose | Key Entities | Depends On | External Infra |
+|--------|---------|--------------|------------|----------------|
+| **admin** | Admin identity & access: account lookup, Redis-backed email verification (send/verify), and **WebAuthn/FIDO2 passkey** register + login (Yubico `RelyingParty`) issuing a JWT. Owns `AdminRole`. | `AdminEntity` (tb_admin), `WebAuthnCredentialEntity` (tb_webauthn), `AdminRole` | global/security | Redis, Email/SMTP, WebAuthn, JWT |
+| **blog** | Bilingual blog posts (KR/EN title + LONGTEXT body, image, view counter). Public read/list/title-search + public view increment; admin CRUD. | `BlogEntity` (tb_blog), `Blog` | _(none)_ | GCS (images) |
+| **news** | Bilingual news items linking out to an external URL with a thumbnail. Public read/list; admin CRUD. | `NewsEntity` (tb_news), `News` | _(none)_ | GCS (thumbnails) |
+| **job** | Job postings (department / location / recruit-type / education enums, KR/EN intro & qualification text, start/end dates, active flag). Public read/list + admin CRUD/deactivate; an active/expired split via QueryDSL; a daily scheduler deactivates postings past `endDate`. | `JobEntity` (tb_job), `Job`, `JobInput`, `Department` / `Location` / `RecruitType` / `Education` | _(none)_ | QueryDSL, `@Scheduled` |
+| **recruit** | Job applications: public submit (resolves the target `job`, persists applicant + attachments/portfolio, sends a receipt email + Slack alert), admin list/detail and status transitions (DOCUMENT → interviews → ACCEPTED / REJECTED) with accept/reject emails. | `RecruitEntity` (tb_recruit), `Recruit`, `RecruitInput`, `Status` / `EducationLevel` / `Military` | job | Email, Slack, GCS, QueryDSL |
+| **talent** | Talent pool: public self-registration (unique email) with portfolio + extra URLs, admin list/search, an active flag, and an admin "offer" email to a registered talent. | `TalentEntity` (tb_talent), `Talent` | _(none)_ | Email, GCS, QueryDSL |
+
+### Cross-cutting / Global layers
+
+| Layer | Purpose | Key Types | Depends On | External Infra |
+|-------|---------|-----------|------------|----------------|
+| **global/security** | Stateless JWT auth for admin endpoints; WebAuthn relying-party setup; `CustomUserDetails` / `AdminRole` principal; CORS, CSRF-off, filter ordering (`JwtExceptionFilter` → `JwtAuthenticationFilter`). Selected public endpoints are permitAll; everything else requires authentication. | `CustomUserDetails`, `AdminRole`, `JwtType` | admin | JWT (jjwt HS256), WebAuthn (Yubico), Redis |
+| **global/infra + config + common** | Third-party integrations behind Spring beans (GCS, Email/SMTP + Thymeleaf, Slack) plus shared building blocks (BaseEntity auditing, BaseResponse / PageResponse, RedisRepository, QueryDslConfig, AsyncConfig, request-logging filter). | `BaseEntity`, `BaseResponse`, `RedisRepository` | — | GCS, SMTP, Slack, Redis, QueryDSL |
+
+---
+
+## Domain Interaction Map
+
+All edges below are realized **exclusively in the UseCase layer**: a domain's UseCase injects another domain's `Service` / `QueryService`, or a global infra bean. Domains never inject another domain's repository, and Services never call other Services directly. Only one cross-**domain** edge exists (`recruit → job`); the rest are domain → global infra/security.
+
+| From → To | Via | Reason |
+|-----------|-----|--------|
+| recruit → job | `JobQueryService.find` | Resolve & validate the target job posting when an application is submitted |
+| recruit → global/infra | `EmailService` + `MailTemplateRenderer` / `SlackNotifier` | Receipt + status-change emails (KR/EN) and a Slack alert on a new application |
+| talent → global/infra | `EmailService` + `MailTemplateRenderer` | "Offer" email to a registered talent |
+| admin → global/infra | `EmailService` + Redis (`RedisRepository`) | Email-verification codes; WebAuthn challenge storage |
+| admin → global/security | `JwtProvider` / WebAuthn `RelyingParty` | Issue JWT on passkey login; verify registration / assertion |
+| all domains → global/security | JWT filter + `CustomUserDetails` | Authenticate admin requests; selected endpoints are public |
+
+---
+
+## Key Flows
+
+### 1. Admin sign-in (email verification + WebAuthn passkey → JWT)
+1. `POST /admin/email-verification/send` issues a Redis-stored code to the admin email; `POST /admin/email-verification/verify` marks it verified.
+2. `POST /admin/webauthn/register/start|finish` registers a passkey (Yubico `RelyingParty`, challenge in Redis); `POST /admin/webauthn/login/start|finish` verifies the assertion, bumps the signature count, and returns a JWT (`JsonWebTokenResponse`).
+3. Every non-public request carries the JWT; `JwtAuthenticationFilter` resolves `CustomUserDetails`; `SecurityConfig` permits the public routes (below) and authenticates the rest.
+
+### 2. Public content + management (blog / news / job)
+1. Public: `GET /blog/**`, `GET /news/**`, `GET /job`, `GET /job/list`, and the `PATCH /blog` view-counter are permitAll.
+2. Admin (authenticated): create / update / delete blog, news, job; `PATCH /job` deactivate; `GET /job/list/deactivate` for expired postings.
+3. `JobScheduler` (daily `0 0 0`, Asia/Seoul) deactivates all postings whose `endDate` has passed.
+
+### 3. Recruitment (apply → notify → triage)
+1. `POST /recruit` (public): `RecruitUseCase` validates the job via `JobQueryService`, persists the application + attachments, then sends a receipt email and a Slack alert.
+2. Admin: `GET /recruit` / `/recruit/list`, `PATCH /recruit` status update, `PATCH /recruit/accept|reject` — status flows DOCUMENT → FIRST_INTERVIEW → SECOND_INTERVIEW → ACCEPTED / REJECTED, with accept/reject emails.
+
+### 4. Talent pool
+1. `POST /talent` (public): self-register with a unique email, portfolio, and extra URLs.
+2. Admin: `GET /talent` / `/talent/list` / `/talent/search`, toggle active, and `POST /talent/offer` to email a registered talent.
+
+---
+
+## Infrastructure & Cross-Cutting
+
+| Tech | Purpose | Used By |
+|------|---------|---------|
+| **Google Cloud Storage (GCS)** | Image storage for blog / news / job / recruit / talent; upload via `/gcp/**` | blog, news, recruit, talent, global/infra |
+| **JWT (jjwt HS256) + Spring Security** | Stateless admin auth; public-endpoint allowlist; CORS; CSRF disabled | admin, global/security |
+| **WebAuthn / FIDO2** (Yubico) | Passkey register / login for admins | admin, global/security |
+| **Redis** | Email-verification codes, WebAuthn challenges | admin, global/security, global/infra |
+| **Email / SMTP** (JavaMailSender + Thymeleaf, `@Async`) | Recruitment receipt / accept / reject emails, talent offer (KR/EN templates) | recruit, talent, admin, global/infra |
+| **Slack** (`SlackNotifier`) | Alert on a new job application | recruit, global/infra |
+| **MySQL** via JPA / Hibernate + QueryDSL | Primary store (BaseEntity auditing); `JPAQueryFactory` for paged list / search | all domains, global |
+| **Spring `@Scheduled`** | Daily job-posting expiry | job |
+| **Spring `@Async`** | Off-request email / Slack sends | global/config, recruit, talent |
+
+### Security model
+
+- **Stateless JWT** on all non-public endpoints; the principal is a `CustomUserDetails` carrying `AdminRole`.
+- **Public (permitAll)**: static resources, `/`, `/index.html`, `OPTIONS /**`, `/admin/email-verification/**`, `/admin/webauthn/register/**`, `/admin/webauthn/login/**`, `GET /job`, `GET /job/list`, `POST /recruit`, `/gcp/**`, `GET /blog/**`, `PATCH /blog`, `GET /news/**`, `POST /talent`.
+- **Filter chain**: `JwtExceptionFilter` → `JwtAuthenticationFilter` (registered around `UsernamePasswordAuthenticationFilter`); CSRF disabled, CORS configured.
+- **WebAuthn relying party** is configured for admin passkey login.

--- a/.claude/git-convention.md
+++ b/.claude/git-convention.md
@@ -1,0 +1,135 @@
+# Git Convention
+
+## Do Not Commit
+- Files in `.gitignore` - Never commit even if modified
+
+---
+
+## Commit Rules
+- NEVER commit unless the user explicitly asks you to
+- Only commit when the user says "commit", "커밋해", etc.
+
+---
+
+## Commit Message Format
+```
+label: message
+```
+**❗️Always write commit messages in English**
+
+---
+
+## Branch Naming Format
+```
+label/domain
+```
+
+---
+
+## Commit Labels
+
+| Label | Description |
+|-------|-------------|
+| feat | New feature implementation |
+| fix | Non-urgent bug fix (typos, minor issues) |
+| bug | Critical/urgent bug fix |
+| refactor | Internal code restructuring (no external behavior change) |
+| merge | Branch merge |
+| deploy | Deployment-related changes |
+| docs | Documentation updates |
+| delete | Code or file deletion |
+| note | Comments or annotations |
+| style | Code formatting (no logic changes) |
+| config | Configuration changes |
+| etc | Other changes |
+| tada | Project initialization |
+
+### Commit Message Examples
+```
+feat: add user authentication
+fix: correct typo in error message
+bug: resolve critical login failure
+refactor: extract email setup helper from UseCase
+docs: update API documentation
+style: format code according to guidelines
+config: update database connection settings
+```
+
+### Branch Naming Examples
+```
+feat/auth
+fix/user
+bug/payment
+refactor/calendar-cache
+docs/readme
+```
+
+---
+
+## Pull Request Guidelines
+
+1. **Title Format**: Use the branch name as the PR title
+   ```
+   feat/auth
+   fix/user
+   config/deploy-version-tag
+   ```
+
+2. **Merge Commit Message**:
+   - `develop → main`: `merge: {version}` (e.g., `merge: release 0.1.12`)
+   - Other branches → target: `merge: {branch-name}` (e.g., `merge: fix/review-findings`)
+
+3. **Description Template** (`develop → main` PRs must include the current version in the body):
+   ```
+   ## 제목
+   ## 작업한 내용
+   ## 전달할 추가 이슈
+   ```
+
+4. **Review Process**:
+   - Request review from at least one team member
+   - Address all review comments before merging
+   - Ensure CI/CD passes before merge
+
+---
+
+## Work Procedure
+
+Follow this procedure for all code modifications:
+
+1. **Create Issue**
+   - Assignees: `lgwk42` (always fixed)
+   - Label: Match the issue type (`Feature`, `Fix`, `Bug`, etc.)
+   - Issue type: Match the issue type
+   - Template: Use Task template (`## 작업 개요`, `## TO DO`, `## 전달할 추가 이슈`)
+
+2. **Create Branch**
+   - Format: `label/domain` (e.g., `fix/stt-notification`, `feat/auth`)
+   - Branch from develop
+
+3. **Implement Changes**
+   - Commit per class unit
+   - Verify build before committing
+
+4. **Version Bump and Commit**
+   - For single-branch work, include version bump (`build.gradle`) in the commit
+   - Commit message: `config: bump version to x.x.x`
+
+5. **Push**
+   - Push only when the user explicitly instructs (`"push"`, etc.)
+   - Never push automatically without instruction
+
+6. **Create PR and Link Issue**
+   - Title: Use branch name (e.g., `fix/stt-notification`)
+   - Body: Link issue with `Closes #N` for auto-close
+   - Assignees: `lgwk42` (always fixed)
+   - Label: Match the PR type
+
+---
+
+## Code Review Checklist
+- [ ] Code follows project conventions
+- [ ] No unnecessary changes included
+- [ ] Tests pass (if applicable)
+- [ ] Documentation updated (if needed)
+- [ ] No security vulnerabilities introduced

--- a/.claude/infrastructure.md
+++ b/.claude/infrastructure.md
@@ -1,0 +1,399 @@
+# Infrastructure
+
+## Security & Authentication
+
+### JWT Implementation
+- **Token Types**: `ACCESS` and `REFRESH` (enum-based)
+- **Algorithm**: HS256 (HMAC-SHA256)
+- **Token Location**: Authorization header with "Bearer " prefix
+
+### Filter Chain Order
+```
+1. JwtExceptionFilter     → Handles JWT-related exceptions
+2. JwtAuthenticationFilter → Validates token, sets SecurityContext
+3. ApiLogFilter           → Logs request/response
+```
+
+### Role-Based Access Control
+| Role | Description |
+|------|-------------|
+| USER | Basic authenticated user |
+| ADMIN | Organization administrator |
+| OWNER | Organization owner |
+| MASTER | System administrator |
+
+### Security Annotations
+```java
+// Endpoint protection in SecurityConfig
+.requestMatchers(HttpMethod.POST, "/organization/invitation").hasAnyRole(ADMIN, OWNER, MASTER)
+.requestMatchers(HttpMethod.GET, "/user/list").hasAnyRole(USER, ADMIN, OWNER, MASTER)
+```
+
+---
+
+## Exception Handling
+
+### Exception Hierarchy
+```
+RuntimeException
+└── BusinessException (base)
+    └── Domain-specific exceptions (e.g., OrganizationNotFoundException)
+```
+
+### Per-Domain Error Enum Pattern
+```java
+// domain/{domain}/exception/{Domain}Error.java
+public enum OrganizationError implements ErrorProperty {
+    ORGANIZATION_NOT_FOUND(HttpStatus.NOT_FOUND, "Organization not found"),
+    INVALID_CODE(HttpStatus.BAD_REQUEST, "Invalid invitation code"),
+    LICENSE_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "License limit exceeded");
+
+    private final HttpStatus status;
+    private final String message;
+}
+```
+
+### Singleton Exception Pattern
+```java
+// domain/{domain}/exception/{Domain}NotFoundException.java
+public class OrganizationNotFoundException extends BusinessException {
+    public static final OrganizationNotFoundException EXCEPTION = new OrganizationNotFoundException();
+    private OrganizationNotFoundException() {
+        super(OrganizationError.ORGANIZATION_NOT_FOUND);
+    }
+}
+
+// Usage in Service
+throw OrganizationNotFoundException.EXCEPTION;
+```
+
+### Global Exception Handlers
+- **Location**: `global/exception/handler/`
+- `ExceptionAdvice` - Handles `BusinessException`
+- `ValidationExceptionAdvice` - Handles validation errors
+
+---
+
+## Validation
+
+### Request Validation
+```java
+@PostMapping
+@ResponseStatus(HttpStatus.CREATED)
+public BaseResponseData<String> register(
+        @RequestBody @Valid final RegisterRequest request
+) {
+    // ...
+}
+```
+
+### Common Validation Annotations
+- `@NotNull`, `@NotBlank` - Required fields
+- `@Positive` - Positive numbers
+- `@Valid` - Nested object validation
+
+---
+
+## QueryDSL Integration
+
+### Query Repository Pattern
+```java
+// domain/{domain}/domain/repository/query/{Domain}QueryRepository.java
+@Repository
+@RequiredArgsConstructor
+public class ClientQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<ClientEntity> findAllClients(int page, int size, String userId, String organizationId) {
+        return jpaQueryFactory
+            .selectFrom(clientEntity)
+            .where(builder)
+            .offset((long) (page - 1) * size)
+            .limit(size)
+            .orderBy(clientEntity.createdAt.desc())
+            .fetch();
+    }
+
+}
+```
+
+### Query Service Pattern
+```java
+// domain/{domain}/application/query/{Domain}QueryService.java
+@Service
+@RequiredArgsConstructor
+public class ClientQueryService {
+
+    private final ClientQueryRepository queryRepository;
+
+    public List<Client> findAll(int page, int size, String userId, String organizationId) {
+        return queryRepository.findAllClients(page, size, userId, organizationId)
+            .stream()
+            .map(Client::of)
+            .toList();
+    }
+
+}
+```
+
+---
+
+## Pagination
+
+### PageRequest DTO
+```java
+// global/common/dto/request/PageRequest.java
+@Getter
+@Setter
+public class PageRequest {
+    @NotNull @Positive private int page;
+    @NotNull @Positive private int size;
+}
+```
+
+### Usage in API Handler
+```java
+@GetMapping("/list")
+public BaseResponseData<List<ClientResponse>> getClients(
+        @ModelAttribute @Valid final PageRequest pageRequest
+) {
+    return BaseResponseData.ok("Success", useCase.getClients(pageRequest));
+}
+```
+
+---
+
+## External Service Integrations
+
+### Location
+All external service integrations are in `global/infra/`
+
+### Firebase Cloud Messaging (FCM)
+- **Location**: `global/infra/fcm/`
+- Push notification service
+- Token stored in `FcmEntity`
+
+### Google Cloud Storage (GCS)
+- **Location**: `global/infra/gcs/`
+- File upload/download/delete
+- Supported types: WAV, PNG, JPG, JPEG
+- URL format: `https://storage.googleapis.com/{bucket}/{uuid}`
+
+### Email Service
+- **Location**: `global/infra/email/`
+- SMTP-based with `@Async` for non-blocking
+- Thymeleaf template support via `MailTemplateRenderer`
+
+### Toss Payments
+- **Location**: `global/infra/toss/`
+- WebClient-based REST client
+- Basic auth with Base64 encoding
+
+---
+
+## Async Configuration
+
+### Thread Pool Settings
+```java
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("async-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        return executor;
+    }
+}
+```
+
+### Usage
+```java
+@Async
+public void sendEmail(String to, String subject, String content) {
+    // Non-blocking email sending
+}
+```
+
+---
+
+## API Logging
+
+### ApiLogFilter
+- **Location**: `global/log/filter/ApiLogFilter.java`
+- Logs all API requests/responses (except `/`, `/index.html`, `/sse`)
+- Captures: User ID, URI, HTTP method, client IP, status code, duration, response message
+
+### Log Entity
+- Stored in database for audit trail
+- Accessible via `/log` endpoint (MASTER role only)
+
+---
+
+## Redis Repository
+
+### Interface
+```java
+public interface RedisRepository {
+    void save(String key, Object value, long timeout, TimeUnit unit);
+    <T> T getByKey(String key, Class<T> type);
+    void editByKey(String key, Object value, long timeout, TimeUnit unit);
+    void delete(String key);
+}
+```
+
+---
+
+## Configuration Profiles
+
+### Profile Structure
+- `application.yml` - Production (secrets from environment variables)
+- `application-dev.yml` - Development
+- `application-local.yml` - Local development
+
+### Key Configurations
+```yaml
+# Database
+spring.datasource.url: ${secrets.DATABASE_URL}
+spring.jpa.hibernate.ddl-auto: none  # prod: none, dev: update
+
+# File Upload
+spring.servlet.multipart.max-file-size: 120MB
+spring.servlet.multipart.max-request-size: 120MB
+
+# JWT
+application.jwt.secret-key: ${secrets.JWT_SECRET}
+application.jwt.expiration: 86400000      # 24 hours
+application.jwt.refresh-expiration: 604800000  # 7 days
+```
+
+### Configuration Properties Pattern
+```java
+@ConfigurationProperties(prefix = "application.jwt")
+public record JwtProperties(
+    String secretKey,
+    long expiration,
+    long refreshExpiration
+) {}
+```
+
+---
+
+## WebClient Configuration
+
+### Multiple WebClient Beans
+```java
+// global/config/web/WebClientConfig.java
+@Bean
+public WebClient sttWebClient() {
+    // 5s connection, 3min response timeout
+}
+
+@Bean
+public WebClient tossWebClient() {
+    // 5s connection, 3min response timeout
+}
+```
+
+---
+
+## Base Classes
+
+### BaseEntity
+```java
+@SuperBuilder
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}
+```
+
+### BaseResponse & BaseResponseData
+```java
+// All API responses use these
+BaseResponse.ok("Success message");
+BaseResponseData.ok("Success message", data);
+BaseResponseData.created("Created message", data);
+```
+
+---
+
+## Key File Locations
+
+| Pattern | File Path |
+|---------|-----------|
+| Security Config | `global/security/config/SecurityConfig.java` |
+| JWT Provider | `global/security/jwt/JwtProvider.java` |
+| Base Entity | `global/common/entity/BaseEntity.java` |
+| Base Response | `global/common/dto/response/BaseResponse.java` |
+| Exception Advice | `global/exception/handler/ExceptionAdvice.java` |
+| QueryDSL Config | `global/config/query/QueryDslConfig.java` |
+| Async Config | `global/config/async/AsyncConfig.java` |
+| API Log Filter | `global/log/filter/ApiLogFilter.java` |
+
+---
+
+## API Documentation Format
+
+### Response Structure
+Document API responses using table format with the following columns:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| fieldName | Type | Field description |
+
+### Example Documentation
+
+**Endpoint**: `GET /meeting/{meetingId}`
+
+**Response**:
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| id | String | Meeting ID |
+| userId | String | User ID |
+| organizationId | String | Organization ID |
+| client | Object | Client information |
+| client.id | String | Client ID |
+| client.name | String | Client name |
+| client.email | String | Client email |
+| client.phoneNumber | String | Client phone number |
+| client.companyName | String | Client company name |
+| stt | Object | Speech-to-text information |
+| stt.textList | Array | List of transcribed text segments |
+| stt.textList[].start | double | Start time (seconds) |
+| stt.textList[].end | double | End time (seconds) |
+| stt.textList[].word | String | Transcribed word/sentence |
+| stt.textList[].speakerId | int | Speaker identifier |
+| stt.jobStatus | String | Job status (RUNNING, DONE, ERROR) |
+| follow | Object | Follow-up information |
+| follow.followType | String | Follow type (NONE, ONLINE, OFFLINE) |
+| follow.customTagList | Array | List of custom tags |
+| follow.customTagList[].idx | Long | Tag index |
+| follow.customTagList[].tag | String | Tag name |
+| createdAt | LocalDateTime | Creation timestamp |
+| modifiedAt | LocalDateTime | Last modification timestamp |
+
+### Nested Object Notation
+- Use dot notation for nested objects: `client.name`
+- Use bracket notation for array items: `textList[]`
+- Combine for nested arrays: `textList[].word`
+
+### Type Conventions
+| Java Type | Documentation Type |
+|-----------|-------------------|
+| String | String |
+| Long, Integer, int | Long, Integer, int |
+| double, Double | double |
+| LocalDateTime | LocalDateTime |
+| List<T> | Array |
+| Custom Object | Object |
+| Enum | String (with possible values) |

--- a/.claude/java-code-style.md
+++ b/.claude/java-code-style.md
@@ -1,0 +1,207 @@
+# Java Code Style
+
+## Basic Principles
+- Based on Google Java Style Guide
+- Indentation: 1 tab (4 spaces)
+- Column limit: 120 characters
+- Wildcard imports prohibited (`java.util.*` not allowed)
+- `var` type inference prohibited
+
+---
+
+## Import Ordering
+```
+java.*
+javax.*
+org.*
+com.*
+
+(blank line)
+
+static imports
+```
+- Follow IntelliJ default import ordering
+- Each group separated by blank line
+- Alphabetical within each group
+
+---
+
+## Naming Conventions
+| Target | Style | Example |
+|--------|-------|---------|
+| Class | UpperCamelCase | `AuthServiceImpl` |
+| Method | lowerCamelCase (verb) | `saveUser` |
+| Constant | CONSTANT_CASE | `MY_NUMBER` |
+| Field/Parameter | lowerCamelCase | `userName` |
+| Boolean variable | `is` prefix | `isChecked` |
+
+---
+
+## Brace Rules
+```java
+public class Example {
+
+    public String testMethod() {
+        int a = 1;
+        if (a != 0) {
+            try {
+                testMethod();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return "test";
+        } else if (a == 1) {
+            return "fail";
+        } else {
+            return "1234";
+        }
+    }
+
+    public void methodWithManyParams(
+        String parameter1,
+        String parameter2,
+        String parameter3
+    ) {}
+
+    public void blankMethod() {}
+
+}
+```
+
+---
+
+## Blank Line Rules
+- After class declaration: blank line
+- Before closing brace: blank line
+- Between methods: 1 blank line
+- **Inside methods: NO blank lines**
+
+---
+
+## Operators
+- 1 space before and after all operators: `a = 1`, `b != 1`
+
+---
+
+## Comments
+
+**General Rules**
+- `/** */` (Javadoc): **Only** for public/protected class, method, field API documentation
+- `/* */` (Block comment): Multi-line implementation comments (2+ lines)
+- `//` (Line comment): Single-line implementation comments, 1 space after `//`, place directly above related code
+- **Do NOT use `/** */` for implementation comments** — it causes Javadoc tooling issues
+
+**Javadoc for Methods**
+- Use Javadoc (`/** */`) for public/protected methods
+- Private methods: Use `//` for simple explanations
+- Include `@param`, `@return` tags
+- `@param` does NOT include the type (type is already in the signature)
+- `@return` is omitted for void methods
+
+**Javadoc Format**
+```java
+/**
+ * Method description
+ * @param paramName Parameter description
+ * @return Return value description
+ */
+public ReturnType methodName(ParamType paramName) {
+    // ...
+}
+```
+
+**Example**
+```java
+/**
+ * GCS 파일 정보 저장
+ * @param id 파일 ID (UUID)
+ * @param fileUrl 파일 URL
+ * @param contentType 파일 타입
+ * @param durationMinutes 오디오 파일 길이 (분 단위, 오디오가 아니면 null)
+ */
+@Transactional
+public void save(String id, String fileUrl, String contentType, Long durationMinutes) {
+    // ...
+}
+```
+
+**Field Comments**
+- Use `//` above field for implementation notes
+```java
+// 크레딧 (분 단위, null이면 크레딧 없음)
+private Long credit;
+```
+
+---
+
+## Long Type
+- Uppercase suffix: `300000L`
+
+---
+
+## Annotation Ordering
+
+**By length (shortest → longest), alphabetical if equal**
+```java
+@Entity
+@Getter
+@SuperBuilder
+@Table(name = "tb_user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserEntity {
+    // ...
+}
+```
+
+---
+
+## DTO Rules
+
+**Use Record Classes**
+```java
+public record Json(
+        String videoId,
+        String groupId,
+        String sessionId,
+        Occupancy occupancy,
+        List<TimeLine> timeLine,
+        DwellTime dwellTime
+) {
+    public static Json to(JsonEntity entity) {
+        return new Json(
+                entity.getVideoId(),
+                entity.getGroupId(),
+                entity.getSessionId(),
+                entity.getOccupancy(),
+                entity.getTimeLine(),
+                entity.getDwellTime()
+        );
+    }
+}
+```
+- Entity → DTO conversion method name: `to`
+- Entity → Domain conversion method name: `of`
+- Domain → Response conversion method name: `of`
+
+---
+
+## Other Rules
+
+### Exception Handling
+- Custom per domain: `UserNotFound`, `FileNotFound`
+
+### Enum
+- Uppercase, use `_` for separation: `USER_NOT_FOUND`
+
+### Parameter Naming
+- Request DTO: `request`
+- Entity: `entity`
+- If 2+ of same type: use class name
+
+### Constructor Injection
+```java
+private final VideoJpaRepository videoJpaRepository;
+```
+
+### Overriding
+- Always add `@Override` (omit if parent is Deprecated)

--- a/.claude/layer-conventions.md
+++ b/.claude/layer-conventions.md
@@ -1,0 +1,119 @@
+# Layer-specific Conventions
+
+## ApiHandler (Controller)
+
+**Annotations**
+```java
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/{domain}")
+```
+
+**Request URI Rules**
+- Match domain name: `/auth`
+- List returns: append `/list`
+- Search API: append `/search`
+
+**Request Rules**
+- All parameters require `final`
+- POST: Prefer `@RequestBody` (use `@RequestParam` if ≤1 parameter)
+- GET: Prefer `@RequestParam` (use `@ModelAttribute` if ≥2 parameters)
+- Others: `@RequestParam` if ≤1, `@RequestBody` if ≥2
+
+**Response Rules**
+```java
+@PostMapping("/sign-in")
+public BaseResponseData<JsonWebTokenResponse> signIn(
+        @RequestBody @Valid final SignInRequest request
+) {
+    return BaseResponseData.ok(
+            "Login successful",
+            authUseCase.signIn(request)
+    );
+}
+```
+- Use `BaseResponse` / `BaseResponseData`
+- Only in Controller (prohibited in Service layer)
+
+---
+
+## UseCase
+
+**When to use**: When 2+ domains interact, or when Service + QueryService need to be combined
+
+**Role**: Facade pattern — orchestrates multiple Services/QueryServices
+
+**Annotations**
+```java
+@Component
+@RequiredArgsConstructor
+```
+
+---
+
+## Service (Command)
+
+**Rules**
+- **CQS**: Only command operations (save, edit, delete)
+- Inject only one Repository (no service-to-service dependency)
+- One method = one responsibility
+- **Return Domain objects or void, NOT DTOs**
+- Query operations go in QueryService
+
+**Annotations**
+```java
+@Service
+@RequiredArgsConstructor
+```
+
+---
+
+## QueryService (Query)
+
+**Rules**
+- **CQS**: Only query operations (find, check, exists)
+- Inject only ONE domain's repositories — its `JpaRepository` and/or its `QueryRepository` may be injected **together** (the QueryDSL idiom: JpaRepository for derived single-entity finders, QueryRepository for dynamic/paged/projection queries). Do NOT inject another domain's repository.
+- Returns Domain objects
+- **Location**: `application/query/` (NOT `application/service/`)
+
+**Annotations**
+```java
+@Service
+@RequiredArgsConstructor
+```
+
+---
+
+## Repository
+
+**Naming**
+- Repository: `{DomainName}JpaRepository`
+- Entity: `{TableName/DomainName}Entity`
+
+**Rules**
+- Extend JpaRepository
+- All columns `private`
+- No `@Setter` (except when necessary)
+- All Entities extend `BaseEntity`
+
+---
+
+## Method Naming Conventions by Layer
+
+| Action | UseCase | Service | QueryService | Entity |
+|--------|---------|---------|-------------|--------|
+| Create | `register` | `save` | - | - |
+| Read (single) | `get` | - | `find` | - |
+| Read (list) | `getAll`, `getList` | - | `findAll`, `findList` | - |
+| Update | `update` | `edit` | - | `edit{Field}` |
+| Delete | `delete` | `delete` | - | `delete` |
+| Validate | `check` | - | `check`, `exists` | - |
+
+### Examples
+```
+UseCase.update()       → Service.edit()        → Entity.editUser()
+UseCase.getById()      → QueryService.find()
+UseCase.register()     → Service.save()
+UseCase.delete()       → Service.delete()       → Entity.delete()
+UseCase.checkExists()  → QueryService.exists()
+```

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,8 +18,10 @@ reviews:
   path_instructions:
     - path: "src/main/java/**/*.java"
       instructions: >-
-        이 백엔드의 컨벤션 위반을 리뷰 기준으로 삼아라.
-        (컨벤션 원문 CLAUDE.md / .claude/*.md 는 이 저장소에서 .gitignore 대상이라 커밋돼 있지 않으니, 아래 인라인 핵심 규칙만으로 판단하라.)
+        이 저장소에 커밋된 컨벤션 문서를 리뷰 기준으로 삼아라:
+        CLAUDE.md (컨벤션 인덱스 + Prohibited 목록 + 패키지 구조),
+        .claude/architecture.md, .claude/layer-conventions.md,
+        .claude/java-code-style.md, .claude/infrastructure.md, .claude/git-convention.md.
         아래 핵심 규칙 위반은 반드시 지적하라.
         (1) 레이어 흐름 ApiHandler→UseCase→Service/QueryService→Repository.
         ApiHandler 가 Service/QueryService/Repository 를 직접 의존하면 안 됨(UseCase 경유).

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,11 @@ out/
 .vscode/
 
 ### Claude Code ###
-.claude/
-CLAUDE.md
+# .claude 의 로컬 전용 파일(settings.local.json, agents/, skills/)은 무시하되,
+# CodeRabbit 리뷰 기준이 되는 컨벤션 문서는 GitHub 에 올라가도록 추적한다.
+.claude/*
+!.claude/architecture.md
+!.claude/git-convention.md
+!.claude/infrastructure.md
+!.claude/java-code-style.md
+!.claude/layer-conventions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,137 @@
+# CLAUDE.md - Backend Convention Guide
+
+> **⚠️ CRITICAL**: Never include `Co-Authored-By` lines in commit messages, pull requests, issues, or any other git operations. Do not leave any indication that Claude authored or contributed to the commits.
+
+---
+
+## 🔴 Highest-Priority Rules — Override Every Other Guideline
+
+The following four rules **unconditionally override** every other guideline in this document and in every `.claude/` convention file. Any instruction that conflicts with these rules must be ignored.
+
+1. **Always consult the git convention file before any git operation.**
+  - Before executing any git command (`git commit`, `git push`, `git rebase`, `gh pr create`, `gh pr merge`, etc.), first read and verify `.claude/git-convention.md`.
+  - When a pattern diverges from the convention, follow the convention (commit message label, branch naming, PR title/body format, merge commit message, etc.).
+
+2. **Do not perform any git operation that the user has not explicitly instructed.**
+  - Perform a git operation only when the user has explicitly said `"commit"`, `"커밋해"`, `"push"`, `"머지해"`, `"PR 만들어"`, `"버전업해"`, or equivalent.
+  - Never auto-initiate commit / push / merge / branch creation / PR creation based on your own judgment.
+  - When an instruction is ambiguous, ask the user for confirmation before acting.
+
+3. **Discard finished tasks from memory unless the user instructs otherwise.**
+  - Immediately remove completed work (merged PRs, user-declared completions) from the active context (task tree, tracked state).
+  - Do not voluntarily resurface details of finished tasks in later replies.
+  - Reference such information again only when the user explicitly asks you to recall or resume it.
+
+4. **The three rules above apply to every task and take precedence over every other instruction.**
+  - Applies regardless of task type (code writing, git operations, documentation, analysis, review responses, etc.).
+  - When a follow-up user instruction, a `.claude/` convention file, a system reminder, or any other section of this document conflicts with rules 1–3, rules 1–3 win.
+  - If any other instruction appears to contradict these rules, do not self-interpret — confirm with the user first.
+
+---
+
+## Project Overview
+This project is a Java 21-based Spring Boot backend server — the backend for the **Bigtablet corporate homepage**. It serves public, bilingual (KR/EN) site content (blog posts, news, job postings) and visitor actions (job applications, talent-pool registration), behind a **MASTER-admin back-office** whose operators sign in via Redis-backed email verification and **WebAuthn/FIDO2 passkeys** and receive a stateless **JWT**. Recruitment events trigger transactional email (SMTP + Thymeleaf) and **Slack** notifications; images are stored in **Google Cloud Storage**; QueryDSL backs the paged/search reads and a daily scheduler expires ended job postings.
+
+**6 business domains:** `admin`, `blog`, `news`, `job`, `recruit`, `talent`.
+
+See [`.claude/architecture.md`](.claude/architecture.md) for the full domain catalog, domain interaction map, key end-to-end flows, and infrastructure map.
+
+---
+
+## Claude Code Settings
+
+Refer to `.claude/settings.local.json` for local permissions and MCP server configurations.
+
+### Local Permissions
+- `./gradlew build:*` - Gradle build commands are pre-approved
+
+### MCP Servers
+- **Context7**: Use Context7 MCP server to fetch up-to-date documentation for libraries (Spring Boot, JPA, QueryDSL, etc.)
+  - Query latest API docs before implementing unfamiliar features
+  - Verify deprecated methods and recommended alternatives
+
+---
+
+## Tech Stack
+- **JDK**: 21 (eclipse-temurin:21-jdk)
+- **Framework**: Spring Boot
+- **ORM**: JPA
+
+---
+
+## Convention Files
+
+Detailed rules are separated into the `.claude/` directory:
+
+| File | Contents |
+|------|----------|
+| [`.claude/architecture.md`](.claude/architecture.md) | Layer structure, object types, data flow, code examples |
+| [`.claude/java-code-style.md`](.claude/java-code-style.md) | Code style, naming, imports, comments, annotation ordering, DTO rules |
+| [`.claude/layer-conventions.md`](.claude/layer-conventions.md) | ApiHandler/UseCase/Service/QueryService/Repository conventions, method naming |
+| [`.claude/git-convention.md`](.claude/git-convention.md) | Commit/branch/PR rules, work procedure, code review checklist |
+| [`.claude/infrastructure.md`](.claude/infrastructure.md) | Security, JWT, Exception, Validation, QueryDSL, external integrations, configuration |
+
+---
+
+## Package Structure
+
+```
+src/main/java/com/bigtablet/bigtablethompageserver/
+├── global/                          # Cross-cutting concerns
+│   ├── common/                      # Shared utilities
+│   │   ├── dto/                     # BaseResponse, PageRequest
+│   │   ├── entity/                  # BaseEntity
+│   │   ├── repository/redis/        # RedisRepository (+ impl)
+│   │   └── util/                    # Shared helpers
+│   ├── config/                      # Configuration classes
+│   │   ├── async/                   # AsyncConfig
+│   │   ├── email/                   # EmailConfig
+│   │   ├── query/                   # QueryDslConfig
+│   │   ├── redis/                   # RedisConfig
+│   │   └── web/                     # Web/CORS config
+│   ├── exception/                   # Exception handling
+│   │   ├── error/                   # ErrorCode, ErrorProperty
+│   │   └── handler/                 # ExceptionAdvice, ValidationExceptionAdvice
+│   ├── infra/                       # External service integrations
+│   │   ├── email/                   # EmailService, MailTemplateRenderer (SMTP + Thymeleaf)
+│   │   ├── filter/                  # RequestLoggingFilter
+│   │   ├── gcp/                     # Google Cloud Storage
+│   │   └── slack/                   # SlackNotifier
+│   └── security/                    # Security configuration
+│       ├── admin/                   # Admin auth properties
+│       ├── auth/                    # CustomUserDetails
+│       ├── config/                  # SecurityConfig
+│       ├── jwt/                     # JWT provider, filters, handlers
+│       └── webauthn/                # WebAuthn (Yubico) relying party
+└── domain/                          # Business domains
+    └── {domainName}/
+        ├── client/                  # API layer
+        │   ├── api/                 # ApiHandler (Controller)
+        │   └── dto/request/         # Request DTOs
+        ├── application/             # Application layer
+        │   ├── query/               # QueryServices (CQS queries)
+        │   ├── response/            # Response DTOs
+        │   ├── service/             # Services (CQS commands)
+        │   ├── usecase/             # UseCases
+        │   └── scheduler/           # @Scheduled jobs (where present)
+        ├── domain/                  # Domain layer
+        │   ├── entity/              # JPA Entities
+        │   ├── enums/               # Enum types (where present)
+        │   ├── model/               # Domain objects
+        │   └── repository/          # jpa/ (JpaRepository) + query/ (QueryRepository)
+        └── exception/               # Domain-specific exceptions (+ error/ enum)
+```
+
+---
+
+## Prohibited
+- [ ] Wildcard imports
+- [ ] `var` type inference
+- [ ] C-style array declaration (`String args[]`)
+- [ ] Blank lines inside methods
+- [ ] BaseResponse in Service layer
+- [ ] Unnecessary @Setter on Entity
+- [ ] Request/Response DTO in Service layer
+- [ ] Service-to-Service dependency injection (use UseCase to combine)
+- [ ] Query methods in Service (move to QueryService)
+- [ ] Command methods in QueryService (move to Service)


### PR DESCRIPTION
## 제목
컨벤션 문서를 추적해 CodeRabbit 이 읽을 수 있게 (CLAUDE.md + .claude/*.md)

## 작업한 내용
- `.gitignore` 수정: `.claude/` 전체 무시 → `.claude/*` 무시 후 **컨벤션 문서 5종만 추적**(`!` 부정):
  `architecture.md`, `git-convention.md`, `infrastructure.md`, `java-code-style.md`, `layer-conventions.md`.
  `CLAUDE.md` 무시 라인 제거 → 추적.
  **로컬 전용 파일은 계속 무시**: `.claude/settings.local.json`, `.claude/agents/`, `.claude/skills/` (`git check-ignore`로 확인 완료).
- 위 6개 문서를 신규 추적 파일로 커밋(= GitHub 에 업로드).
- `.coderabbit.yaml` 복원: 문서가 이제 커밋되므로 `path_instructions`가 다시 그 문서들을 리뷰 기준으로 참조(이전 #156에서 gitignore 때문에 인라인 규칙만 두었던 것을 되돌림).

## 효과
CodeRabbit 이 인라인 규칙 + **실제 컨벤션 문서 전문**을 모두 근거로 리뷰. 민감/로컬 설정은 여전히 비공개.

## 비고
- 머지 안 함(피어/CI 게이트 대기).
- 커밋되는 문서에 시크릿 없음(전부 컨벤션/아키텍처 설명). 실제 시크릿은 `settings.local.json`에 있고 계속 ignore 유지.
