### PR TITLE
bug/security

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
@@ -13,6 +13,7 @@ public record RegisterRecruitRequest(
         @NotNull
         Long jobId,
         @NotBlank
+        @Pattern(regexp = "^[^\\r\\n]+$", message = "이름에 줄바꿈 문자를 포함할 수 없습니다.")
         String name,
         @NotBlank
         String phoneNumber,

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/JwtProvider.java
@@ -2,15 +2,12 @@ package com.bigtablet.bigtablethompageserver.global.security.jwt;
 
 import com.bigtablet.bigtablethompageserver.global.security.jwt.config.JwtProperties;
 import com.bigtablet.bigtablethompageserver.global.security.jwt.enums.JwtType;
+import com.bigtablet.bigtablethompageserver.global.security.jwt.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -35,7 +32,8 @@ public class JwtProvider {
     }
 
     /**
-     * JWT 토큰 파싱 및 검증
+     * JWT 토큰 파싱 및 검증. 만료/서명 실패/손상 등 모든 검증 실패는
+     * 인증 실패 사유를 노출하지 않도록 InvalidTokenException(401)으로 통일해 던진다.
      * @param token JWT 토큰 문자열
      * @return Jws<Claims> 검증된 클레임 정보
      */
@@ -45,16 +43,8 @@ public class JwtProvider {
                     .verifyWith(getSigningKey())
                     .build()
                     .parseSignedClaims(token);
-        } catch (ExpiredJwtException e) {
-            throw new IllegalArgumentException("만료된 토큰", e);
-        } catch (SecurityException | SignatureException e) {
-            throw new IllegalArgumentException("서명 검증 실패", e);
-        } catch (MalformedJwtException e) {
-            throw new IllegalArgumentException("손상된 토큰", e);
-        } catch (UnsupportedJwtException e) {
-            throw new IllegalArgumentException("지원되지 않는 토큰", e);
         } catch (JwtException | IllegalArgumentException e) {
-            throw new IllegalArgumentException("잘못된 토큰", e);
+            throw InvalidTokenException.EXCEPTION;
         }
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/exception/InvalidTokenException.java
@@ -1,0 +1,13 @@
+package com.bigtablet.bigtablethompageserver.global.security.jwt.exception;
+
+import com.bigtablet.bigtablethompageserver.global.exception.BusinessException;
+import com.bigtablet.bigtablethompageserver.global.security.jwt.exception.error.JwtTokenError;
+
+public class InvalidTokenException extends BusinessException {
+
+    public static final InvalidTokenException EXCEPTION = new InvalidTokenException();
+
+    private InvalidTokenException() {
+        super(JwtTokenError.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/exception/error/JwtTokenError.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/exception/error/JwtTokenError.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum JwtTokenError implements ErrorProperty {
 
-    JWT_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "잘못된 타입");
+    JWT_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "잘못된 타입"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
@@ -20,15 +20,11 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain filterChain) throws IOException {
+                                    FilterChain filterChain) throws IOException, ServletException {
         try {
             filterChain.doFilter(request, response);
         } catch (BusinessException e) {
             setErrorResponse(e.getError().getStatus(), response, e.getError().getMessage());
-        } catch (IllegalArgumentException e) {
-            setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getMessage());
-        } catch (ServletException e) {
-            throw new IOException(e);
         }
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.global.security.jwt.filter;
 
+import com.bigtablet.bigtablethompageserver.global.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -22,22 +23,24 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws IOException {
         try {
             filterChain.doFilter(request, response);
+        } catch (BusinessException e) {
+            setErrorResponse(e.getError().getStatus(), response, e.getError().getMessage());
         } catch (IllegalArgumentException e) {
-            setErrorResponse(HttpStatus.UNAUTHORIZED, response, e);
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getMessage());
         } catch (ServletException e) {
-            setErrorResponse(HttpStatus.BAD_REQUEST, response, e);
+            setErrorResponse(HttpStatus.BAD_REQUEST, response, e.getMessage());
         }
     }
 
     public void setErrorResponse(HttpStatus status,
                                  HttpServletResponse response,
-                                 Throwable ex) throws IOException {
+                                 String message) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(status.value());
         ObjectMapper mapper = new ObjectMapper();
         Map<String, String> map = new HashMap<>();
         map.put("status", String.valueOf(status.value()));
-        map.put("message", ex.getMessage());
+        map.put("message", message);
         response.getWriter().write(mapper.writeValueAsString(map));
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
@@ -28,7 +28,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         } catch (IllegalArgumentException e) {
             setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getMessage());
         } catch (ServletException e) {
-            setErrorResponse(HttpStatus.BAD_REQUEST, response, e.getMessage());
+            throw new IOException(e);
         }
     }
 


### PR DESCRIPTION
## 작업한 내용
- `JwtExceptionFilter`가 `BusinessException`(`TokenTypeException`, `AdminNotFoundException` 등)을 캐치하도록 추가. 기존에는 필터 체인에서 던져진 `BusinessException`이 `@RestControllerAdvice`로도 처리되지 않아(advice는 컨트롤러 예외만 처리) 500 + 스택트레이스가 노출됐다. 이제 `ErrorProperty`의 status/message로 일관된 응답을 반환한다.
- `RegisterRecruitRequest.name`에 `@Pattern(^[^\r\n]+$)` 추가로 CRLF 기반 이메일 헤더 인젝션을 차단. `name`이 메일 제목 문자열에 그대로 연결되던 경로를 입력 단계에서 막는다.

## 검증
- `./gradlew clean compileJava` 통과
- 독립 적대적 검증 pass: catch 순서/시그니처/`getError()` 사용 정확, 정규식이 CR·LF만 차단하고 공백·한글·유니코드는 허용함을 확인

## 전달할 추가 이슈
- 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 채용 등록 요청의 이름 입력값에 줄바꿈 문자가 포함되지 않도록 제한했습니다.
  * 인증 처리 중 발생하는 비즈니스 예외가 더 적절한 상태 코드와 메시지로 응답되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->