### PR TITLE
fix/validation

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
@@ -10,6 +10,7 @@ import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseRespo
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -65,7 +66,7 @@ public class BlogApiHandler {
     public BaseResponseData<List<BlogResponse>> searchBlogByTitle(
             @ModelAttribute
             final PageRequest request,
-            @RequestParam @NotBlank
+            @RequestParam @NotBlank @Size(max = 255)
             final String title
     ) {
         return BaseResponseData.ok(

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/RegisterJobRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/RegisterJobRequest.java
@@ -7,11 +7,13 @@ import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.model.JobInput;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
 public record RegisterJobRequest(
         @NotBlank
+        @Size(max = 255)
         String title,
         @NotNull
         Department department,
@@ -20,18 +22,24 @@ public record RegisterJobRequest(
         @NotNull
         RecruitType recruitType,
         @NotBlank
+        @Size(max = 255)
         String experiment,
         @NotNull
         Education education,
         @NotBlank
+        @Size(max = 10000)
         String companyIntroduction,
         @NotBlank
+        @Size(max = 10000)
         String positionIntroduction,
         @NotBlank
+        @Size(max = 10000)
         String mainResponsibility,
         @NotBlank
+        @Size(max = 10000)
         String qualification,
         @NotBlank
+        @Size(max = 10000)
         String preferredQualification,
         @NotNull
         LocalDate startDate,

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/EditNewsRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/EditNewsRequest.java
@@ -2,18 +2,23 @@ package com.bigtablet.bigtablethompageserver.domain.news.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
 public record EditNewsRequest(
         @NotNull
         Long idx,
         @NotBlank
+        @Size(max = 255)
         String titleKr,
         @NotBlank
+        @Size(max = 255)
         String titleEn,
         @NotBlank
+        @Size(max = 255)
         @URL(message = "유효한 URL 형식이어야 합니다.")
         String newsUrl,
         @NotBlank
+        @Size(max = 255)
         String thumbnailImageUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/EditNewsRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/EditNewsRequest.java
@@ -2,6 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.news.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.URL;
 
 public record EditNewsRequest(
         @NotNull
@@ -11,6 +12,7 @@ public record EditNewsRequest(
         @NotBlank
         String titleEn,
         @NotBlank
+        @URL(message = "유효한 URL 형식이어야 합니다.")
         String newsUrl,
         @NotBlank
         String thumbnailImageUrl

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/RegisterNewsRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/RegisterNewsRequest.java
@@ -1,16 +1,21 @@
 package com.bigtablet.bigtablethompageserver.domain.news.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
 public record RegisterNewsRequest(
         @NotBlank
+        @Size(max = 255)
         String titleKr,
         @NotBlank
+        @Size(max = 255)
         String titleEn,
         @NotBlank
+        @Size(max = 255)
         @URL(message = "유효한 URL 형식이어야 합니다.")
         String newsUrl,
         @NotBlank
+        @Size(max = 255)
         String thumbnailImageUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/RegisterNewsRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/RegisterNewsRequest.java
@@ -8,6 +8,7 @@ public record RegisterNewsRequest(
         String titleKr,
         @NotBlank
         String titleEn,
+        @NotBlank
         @URL(message = "유효한 URL 형식이어야 합니다.")
         String newsUrl,
         @NotBlank

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/SearchTalentRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/SearchTalentRequest.java
@@ -2,6 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request;
 
 import com.bigtablet.bigtablethompageserver.global.common.dto.request.PageRequest;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,6 +11,7 @@ import lombok.Setter;
 public class SearchTalentRequest extends PageRequest {
 
     @NotBlank
+    @Size(max = 100)
     private String keyword;
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/handler/ValidationExceptionAdvice.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/handler/ValidationExceptionAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -27,6 +28,23 @@ public class ValidationExceptionAdvice {
         return ErrorResponse.of(
                 exception
                         .getBindingResult()
+                        .getAllErrors()
+                        .getFirst()
+                        .getDefaultMessage()
+        );
+    }
+
+    /**
+     * `@Validated` 컨트롤러의 메서드 파라미터(`@RequestParam`/`@PathVariable` 등) 제약 위반을 공통 형식으로 처리한다.
+     * Spring 6.1+ / Boot 3.2+ 에서 메서드 파라미터 검증 실패는 HandlerMethodValidationException으로 던져진다.
+     * @param exception 메서드 파라미터 검증 실패 예외
+     * @return ErrorResponse 첫 검증 오류 메시지 응답
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ErrorResponse handleHandlerMethodValidation(HandlerMethodValidationException exception) {
+        return ErrorResponse.of(
+                exception
                         .getAllErrors()
                         .getFirst()
                         .getDefaultMessage()


### PR DESCRIPTION
## 작업한 내용
- news `EditNewsRequest`/`RegisterNewsRequest`의 `newsUrl`에 `@NotBlank + @URL` 적용. 기존 edit는 `@NotBlank`만 있어 잘못된 URL을 통과시키던 불일치를 해소하고, `@URL` 단독 시 발생하는 null/blank 갭(`@Column(nullable=false)` 위반)도 `@NotBlank`로 차단한다.
- job `RegisterJobRequest`: 자유텍스트 필드에 `@Size` 추가 (title/experiment 255, companyIntroduction·positionIntroduction·mainResponsibility·qualification·preferredQualification 10000) — 무제한 저장/메모리·DB DoS 방지.
- blog 검색 `title` `@Size(max=255)`, talent 검색 `keyword` `@Size(max=100)` — unbounded LIKE 쿼리 DoS 방지.

## 검증
- `./gradlew clean compileJava` 통과
- 독립 적대적 검증 pass. (검증 중 news에서 `@NotBlank` 제거로 인한 null-gap 회귀를 발견 → `@NotBlank` 유지로 교정 후 재검증 pass)

## 전달할 추가 이슈
- 동일 관점에서 `EditJobRequest`/`EditBlogRequest`(PUT 경로)에도 `@Size`를 더하면 일관성이 완성됨 (이번 PR 범위 외).
