### PR TITLE
refactor/delete

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
@@ -70,9 +70,7 @@ public class BlogService {
     @Transactional
     public void delete(Long idx) {
         log.info("[BlogService] delete - idx={}", idx);
-        BlogEntity entity = blogJpaRepository
-                .findById(idx)
-                .orElseThrow(() -> BlogNotFoundException.EXCEPTION);
+        BlogEntity entity = getBlogEntity(idx);
         blogJpaRepository.delete(entity);
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
@@ -61,10 +61,10 @@ public class JobService {
     @Transactional
     public void delete(Long idx) {
         log.info("[JobService] delete - idx={}", idx);
-        if (!jobJpaRepository.existsById(idx)) {
-            throw JobNotFoundException.EXCEPTION;
-        }
-        jobJpaRepository.deleteById(idx);
+        JobEntity entity = jobJpaRepository
+                .findById(idx)
+                .orElseThrow(() -> JobNotFoundException.EXCEPTION);
+        jobJpaRepository.delete(entity);
     }
 
 }


### PR DESCRIPTION
## 작업한 내용
- `BlogService.delete`: 형제 메서드(`edit`/`addViews`)와 동일하게 비관적 락(`findByIdxForUpdate`, PESSIMISTIC_WRITE)을 사용하도록 정렬해 delete-edit TOCTOU를 완화. `BlogNotFoundException` 404 계약 유지.
- `JobService.delete`: `existsById()` + `deleteById()`(2쿼리)를 `findById().orElseThrow()` + `delete(entity)` 단일 fetch로 원자화. `JobNotFoundException` 404 계약 유지.

외부 동작(응답 상태/계약) 변화 없이 내부 패턴만 정렬하는 변경이다.

## 검증
- `./gradlew clean compileJava` 통과
- 독립 적대적 검증 pass: 404 계약 유지·락 의미·미사용 import 없음 확인

## 전달할 추가 이슈
- 없음
