### PR TITLE
refactor/config

### DIFF
--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/config/email/MailConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/config/email/MailConfig.java
@@ -1,6 +1,5 @@
 package com.bigtablet.bigtablethompageserver.global.config.email;
 
-import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/config/query/QueryDslConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/config/query/QueryDslConfig.java
@@ -3,18 +3,14 @@ package com.bigtablet.bigtablethompageserver.global.config.query;
 import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class QueryDslConfig {
 
-    @PersistenceContext
-    public EntityManager entityManager;
-
     @Bean
-    public JPAQueryFactory jpaQueryFactory() {
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
         return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 


### PR DESCRIPTION
## 작업한 내용
- `QueryDslConfig`: `public` 필드 `@PersistenceContext` 주입을 `@Bean` 메서드 파라미터 주입(`jpaQueryFactory(EntityManager)`)으로 변경. Spring이 주입하는 공유·스레드세이프 EntityManager 프록시를 그대로 사용하는 표준 패턴이다.
- `MailConfig`: 미사용 import(`jakarta.mail.MessagingException`) 제거.

## 검증
- `./gradlew clean compileJava` 통과
- 독립 적대적 검증 pass: 파라미터 주입의 EntityManager 동작/스레드세이프 유지, MessagingException은 `MailConfig`에서 미사용임을 확인

## 전달할 추가 이슈
- 없음
