### PR TITLE
Develop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.bigtablet'
-version = '1.7.0'
+version = '1.7.1'
 description = 'bigtablet-homepage-server'
 
 java {

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
@@ -70,7 +70,9 @@ public class BlogService {
     @Transactional
     public void delete(Long idx) {
         log.info("[BlogService] delete - idx={}", idx);
-        BlogEntity entity = getBlogEntity(idx);
+        BlogEntity entity = blogJpaRepository
+                .findById(idx)
+                .orElseThrow(() -> BlogNotFoundException.EXCEPTION);
         blogJpaRepository.delete(entity);
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/application/service/BlogService.java
@@ -70,9 +70,7 @@ public class BlogService {
     @Transactional
     public void delete(Long idx) {
         log.info("[BlogService] delete - idx={}", idx);
-        BlogEntity entity = blogJpaRepository
-                .findById(idx)
-                .orElseThrow(() -> BlogNotFoundException.EXCEPTION);
+        BlogEntity entity = getBlogEntity(idx);
         blogJpaRepository.delete(entity);
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
@@ -10,6 +10,7 @@ import com.bigtablet.bigtablethompageserver.global.common.dto.response.BaseRespo
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -65,7 +66,7 @@ public class BlogApiHandler {
     public BaseResponseData<List<BlogResponse>> searchBlogByTitle(
             @ModelAttribute
             final PageRequest request,
-            @RequestParam @NotBlank
+            @RequestParam @NotBlank @Size(max = 255)
             final String title
     ) {
         return BaseResponseData.ok(

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/application/service/JobService.java
@@ -61,10 +61,10 @@ public class JobService {
     @Transactional
     public void delete(Long idx) {
         log.info("[JobService] delete - idx={}", idx);
-        if (!jobJpaRepository.existsById(idx)) {
-            throw JobNotFoundException.EXCEPTION;
-        }
-        jobJpaRepository.deleteById(idx);
+        JobEntity entity = jobJpaRepository
+                .findById(idx)
+                .orElseThrow(() -> JobNotFoundException.EXCEPTION);
+        jobJpaRepository.delete(entity);
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/RegisterJobRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/RegisterJobRequest.java
@@ -7,11 +7,13 @@ import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.model.JobInput;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
 public record RegisterJobRequest(
         @NotBlank
+        @Size(max = 255)
         String title,
         @NotNull
         Department department,
@@ -20,18 +22,24 @@ public record RegisterJobRequest(
         @NotNull
         RecruitType recruitType,
         @NotBlank
+        @Size(max = 255)
         String experiment,
         @NotNull
         Education education,
         @NotBlank
+        @Size(max = 10000)
         String companyIntroduction,
         @NotBlank
+        @Size(max = 10000)
         String positionIntroduction,
         @NotBlank
+        @Size(max = 10000)
         String mainResponsibility,
         @NotBlank
+        @Size(max = 10000)
         String qualification,
         @NotBlank
+        @Size(max = 10000)
         String preferredQualification,
         @NotNull
         LocalDate startDate,

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/EditNewsRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/EditNewsRequest.java
@@ -2,18 +2,23 @@ package com.bigtablet.bigtablethompageserver.domain.news.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
 public record EditNewsRequest(
         @NotNull
         Long idx,
         @NotBlank
+        @Size(max = 255)
         String titleKr,
         @NotBlank
+        @Size(max = 255)
         String titleEn,
         @NotBlank
+        @Size(max = 255)
         @URL(message = "유효한 URL 형식이어야 합니다.")
         String newsUrl,
         @NotBlank
+        @Size(max = 255)
         String thumbnailImageUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/EditNewsRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/EditNewsRequest.java
@@ -2,6 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.news.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.URL;
 
 public record EditNewsRequest(
         @NotNull
@@ -11,6 +12,7 @@ public record EditNewsRequest(
         @NotBlank
         String titleEn,
         @NotBlank
+        @URL(message = "유효한 URL 형식이어야 합니다.")
         String newsUrl,
         @NotBlank
         String thumbnailImageUrl

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/RegisterNewsRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/RegisterNewsRequest.java
@@ -1,16 +1,21 @@
 package com.bigtablet.bigtablethompageserver.domain.news.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
 public record RegisterNewsRequest(
         @NotBlank
+        @Size(max = 255)
         String titleKr,
         @NotBlank
+        @Size(max = 255)
         String titleEn,
         @NotBlank
+        @Size(max = 255)
         @URL(message = "유효한 URL 형식이어야 합니다.")
         String newsUrl,
         @NotBlank
+        @Size(max = 255)
         String thumbnailImageUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/RegisterNewsRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/news/client/dto/request/RegisterNewsRequest.java
@@ -8,6 +8,7 @@ public record RegisterNewsRequest(
         String titleKr,
         @NotBlank
         String titleEn,
+        @NotBlank
         @URL(message = "유효한 URL 형식이어야 합니다.")
         String newsUrl,
         @NotBlank

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
 public record RegisterRecruitRequest(
@@ -14,26 +15,35 @@ public record RegisterRecruitRequest(
         Long jobId,
         @NotBlank
         @Pattern(regexp = "^[^\\r\\n]+$", message = "이름에 줄바꿈 문자를 포함할 수 없습니다.")
+        @Size(max = 255)
         String name,
         @NotBlank
+        @Size(max = 255)
         String phoneNumber,
         @NotBlank
         @Email(message = "이메일 형식이 틀립니다.")
+        @Size(max = 255)
         String email,
         @NotBlank
+        @Size(max = 255)
         String address,
         @NotBlank
+        @Size(max = 255)
         String addressDetail,
         @NotBlank
         @URL(message = "유효한 URL 형식이어야 합니다.")
+        @Size(max = 255)
         String portfolio,
         @URL(message = "유효한 URL 형식이어야 합니다.")
+        @Size(max = 255)
         String coverLetter,
         @NotBlank
         @URL(message = "유효한 URL 형식이어야 합니다.")
+        @Size(max = 255)
         String profileImage,
         @NotNull
         EducationLevel educationLevel,
+        @Size(max = 255)
         String schoolName,
         @Pattern(
                 regexp = "^(19|20)\\d{2}-(0[1-9]|1[0-2])$",
@@ -45,14 +55,18 @@ public record RegisterRecruitRequest(
                 message = "졸업년도는 YYYY-MM 형식이어야 합니다."
         )
         String graduationYear,
+        @Size(max = 255)
         String department,
         @NotNull
         Military military,
         @URL(message = "유효한 URL 형식이어야 합니다.")
+        @Size(max = 255)
         String attachment1,
         @URL(message = "유효한 URL 형식이어야 합니다.")
+        @Size(max = 255)
         String attachment2,
         @URL(message = "유효한 URL 형식이어야 합니다.")
+        @Size(max = 255)
         String attachment3
 ) {
     /**
@@ -83,4 +97,3 @@ public record RegisterRecruitRequest(
                 .build();
     }
 }
-

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/client/dto/request/RegisterRecruitRequest.java
@@ -13,6 +13,7 @@ public record RegisterRecruitRequest(
         @NotNull
         Long jobId,
         @NotBlank
+        @Pattern(regexp = "^[^\\r\\n]+$", message = "이름에 줄바꿈 문자를 포함할 수 없습니다.")
         String name,
         @NotBlank
         String phoneNumber,

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/SearchTalentRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/SearchTalentRequest.java
@@ -2,6 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request;
 
 import com.bigtablet.bigtablethompageserver.global.common.dto.request.PageRequest;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,6 +11,7 @@ import lombok.Setter;
 public class SearchTalentRequest extends PageRequest {
 
     @NotBlank
+    @Size(max = 100)
     private String keyword;
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/config/email/MailConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/config/email/MailConfig.java
@@ -1,6 +1,5 @@
 package com.bigtablet.bigtablethompageserver.global.config.email;
 
-import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/config/query/QueryDslConfig.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/config/query/QueryDslConfig.java
@@ -3,18 +3,14 @@ package com.bigtablet.bigtablethompageserver.global.config.query;
 import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class QueryDslConfig {
 
-    @PersistenceContext
-    public EntityManager entityManager;
-
     @Bean
-    public JPAQueryFactory jpaQueryFactory() {
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
         return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/handler/ValidationExceptionAdvice.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/exception/handler/ValidationExceptionAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -27,6 +28,23 @@ public class ValidationExceptionAdvice {
         return ErrorResponse.of(
                 exception
                         .getBindingResult()
+                        .getAllErrors()
+                        .getFirst()
+                        .getDefaultMessage()
+        );
+    }
+
+    /**
+     * `@Validated` 컨트롤러의 메서드 파라미터(`@RequestParam`/`@PathVariable` 등) 제약 위반을 공통 형식으로 처리한다.
+     * Spring 6.1+ / Boot 3.2+ 에서 메서드 파라미터 검증 실패는 HandlerMethodValidationException으로 던져진다.
+     * @param exception 메서드 파라미터 검증 실패 예외
+     * @return ErrorResponse 첫 검증 오류 메시지 응답
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ErrorResponse handleHandlerMethodValidation(HandlerMethodValidationException exception) {
+        return ErrorResponse.of(
+                exception
                         .getAllErrors()
                         .getFirst()
                         .getDefaultMessage()

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/JwtProvider.java
@@ -2,15 +2,12 @@ package com.bigtablet.bigtablethompageserver.global.security.jwt;
 
 import com.bigtablet.bigtablethompageserver.global.security.jwt.config.JwtProperties;
 import com.bigtablet.bigtablethompageserver.global.security.jwt.enums.JwtType;
+import com.bigtablet.bigtablethompageserver.global.security.jwt.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -35,7 +32,8 @@ public class JwtProvider {
     }
 
     /**
-     * JWT 토큰 파싱 및 검증
+     * JWT 토큰 파싱 및 검증. 만료/서명 실패/손상 등 모든 검증 실패는
+     * 인증 실패 사유를 노출하지 않도록 InvalidTokenException(401)으로 통일해 던진다.
      * @param token JWT 토큰 문자열
      * @return Jws<Claims> 검증된 클레임 정보
      */
@@ -45,16 +43,8 @@ public class JwtProvider {
                     .verifyWith(getSigningKey())
                     .build()
                     .parseSignedClaims(token);
-        } catch (ExpiredJwtException e) {
-            throw new IllegalArgumentException("만료된 토큰", e);
-        } catch (SecurityException | SignatureException e) {
-            throw new IllegalArgumentException("서명 검증 실패", e);
-        } catch (MalformedJwtException e) {
-            throw new IllegalArgumentException("손상된 토큰", e);
-        } catch (UnsupportedJwtException e) {
-            throw new IllegalArgumentException("지원되지 않는 토큰", e);
         } catch (JwtException | IllegalArgumentException e) {
-            throw new IllegalArgumentException("잘못된 토큰", e);
+            throw InvalidTokenException.EXCEPTION;
         }
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/exception/InvalidTokenException.java
@@ -1,0 +1,13 @@
+package com.bigtablet.bigtablethompageserver.global.security.jwt.exception;
+
+import com.bigtablet.bigtablethompageserver.global.exception.BusinessException;
+import com.bigtablet.bigtablethompageserver.global.security.jwt.exception.error.JwtTokenError;
+
+public class InvalidTokenException extends BusinessException {
+
+    public static final InvalidTokenException EXCEPTION = new InvalidTokenException();
+
+    private InvalidTokenException() {
+        super(JwtTokenError.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/exception/error/JwtTokenError.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/exception/error/JwtTokenError.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum JwtTokenError implements ErrorProperty {
 
-    JWT_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "잘못된 타입");
+    JWT_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "잘못된 타입"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -16,10 +15,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
-@RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
 
-    private final ObjectMapper objectMapper;
+    // Spring Boot 4의 자동 설정 ObjectMapper는 Jackson 3(tools.jackson) 빈이라 주입 대신 직접 생성한다.
+    // 싱글톤 필터의 필드로 1회만 생성해 요청마다 재생성하지 않는다. (JwtAuthenticationEntryPoint와 동일 패턴)
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -15,7 +16,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -33,11 +37,10 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
                                  String message) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(status.value());
-        ObjectMapper mapper = new ObjectMapper();
         Map<String, String> map = new HashMap<>();
         map.put("status", String.valueOf(status.value()));
         map.put("message", message);
-        response.getWriter().write(mapper.writeValueAsString(map));
+        response.getWriter().write(objectMapper.writeValueAsString(map));
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
@@ -20,15 +20,11 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain filterChain) throws IOException {
+                                    FilterChain filterChain) throws IOException, ServletException {
         try {
             filterChain.doFilter(request, response);
         } catch (BusinessException e) {
             setErrorResponse(e.getError().getStatus(), response, e.getError().getMessage());
-        } catch (IllegalArgumentException e) {
-            setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getMessage());
-        } catch (ServletException e) {
-            throw new IOException(e);
         }
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.global.security.jwt.filter;
 
+import com.bigtablet.bigtablethompageserver.global.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -22,22 +23,24 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws IOException {
         try {
             filterChain.doFilter(request, response);
+        } catch (BusinessException e) {
+            setErrorResponse(e.getError().getStatus(), response, e.getError().getMessage());
         } catch (IllegalArgumentException e) {
-            setErrorResponse(HttpStatus.UNAUTHORIZED, response, e);
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getMessage());
         } catch (ServletException e) {
-            setErrorResponse(HttpStatus.BAD_REQUEST, response, e);
+            setErrorResponse(HttpStatus.BAD_REQUEST, response, e.getMessage());
         }
     }
 
     public void setErrorResponse(HttpStatus status,
                                  HttpServletResponse response,
-                                 Throwable ex) throws IOException {
+                                 String message) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(status.value());
         ObjectMapper mapper = new ObjectMapper();
         Map<String, String> map = new HashMap<>();
         map.put("status", String.valueOf(status.value()));
-        map.put("message", ex.getMessage());
+        map.put("message", message);
         response.getWriter().write(mapper.writeValueAsString(map));
     }
 

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/security/jwt/filter/JwtExceptionFilter.java
@@ -28,7 +28,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         } catch (IllegalArgumentException e) {
             setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getMessage());
         } catch (ServletException e) {
-            setErrorResponse(HttpStatus.BAD_REQUEST, response, e.getMessage());
+            throw new IOException(e);
         }
     }
 


### PR DESCRIPTION
## 제목
release 1.7.1 — 코드 스캔 리뷰 지적 반영 (보안/검증/리팩터)

## 작업한 내용
적대적 검증 스캔에서 확정된 지적을 성격별 4개 PR로 분리해 develop에 머지한 릴리스입니다. 현재 버전: **1.7.1**

- **bug/security** (#162)
  - `JwtExceptionFilter`가 `BusinessException`만 매핑하고 그 외 예외는 그대로 전파하도록 정리
  - `JwtProvider`가 토큰 검증 실패를 `InvalidTokenException`(401)으로 통일 (인증 실패 사유 노출 제거)
  - `RegisterRecruitRequest.name`에 `@Pattern`으로 CRLF 이메일 헤더 인젝션 차단
- **fix/validation** (#163)
  - news `newsUrl` `@NotBlank + @URL`, news/job/blog/talent 입력 필드에 `@Size` (DoS·DB truncation 방지)
  - `ValidationExceptionAdvice`에 `HandlerMethodValidationException` 핸들러 추가 (메서드 파라미터 검증 실패 공통 응답)
- **refactor/delete** (#164)
  - `BlogService`/`JobService`의 `delete`를 형제 메서드와 동일한 락/단일 fetch 패턴으로 정렬 (404 계약 유지)
- **refactor/config** (#165)
  - `QueryDslConfig` 파라미터 주입, `MailConfig` 미사용 import 제거
- **config**
  - 버전 1.7.0 → 1.7.1

## 전달할 추가 이슈
- `EditJobRequest`/`EditBlogRequest`(PUT 경로)에도 `@Size`를 추가하면 등록/수정 간 길이 검증 일관성이 완성됨 (후속).
- recruit 상태 변경 동시성(낙관/비관 락)은 단일 관리자 환경이라 우선순위 낮음 — 필요 시 별도 처리.
- 권한/소유권 관련 스캔 지적은 "인증=단일 MASTER 관리자" 설계상 정상으로 판단해 제외함.
