### PR TITLE
Develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: "temurin"
 
       - name: Set application.yml values
-        uses: microsoft/variable-substitution@v1
+        uses: microsoft/variable-substitution@6287962da9e5b6e68778dc51e840caa03ca84495 # v1
         with:
           files: src/main/resources/application.yml
         env:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,150 @@
+name: Claude PR Review
+
+# 트리거 모델 (비용 절감):
+#  - PR 최초 열림/재오픈/ready 전환 시 1회 자동 리뷰
+#  - 이후 재리뷰는 PR 코멘트에 `@claude review` / `@claude re-review` / `@gemini review`
+#    중 하나를 남길 때만 실행
+#  - synchronize(푸시마다) 자동 리뷰는 비용 때문에 쓰지 않는다
+# GitHub App 없이 레포 secret(CLAUDE_CODE_REVIEW_API_KEY)으로 직접 인증한다.
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+# 같은 PR 에 새 "리뷰 요청" 이 오면 진행 중인 리뷰를 취소하고 최신 것만 실행.
+# 주의: concurrency 는 job `if:` 보다 먼저 평가된다. 그래서 봇/비-트리거
+# issue_comment(CodeRabbit 등)도 같은 그룹이면 진행 중인 진짜 리뷰를 cancel 시켜버린다
+# (그 run 은 정작 `if:` 에서 skip). → 실제 리뷰 요청 이벤트(pull_request, 또는 트리거
+# 문구가 담긴 issue_comment)만 공유 그룹(`-review`)으로 묶어 supersede 하고,
+# 그 외 run 은 `run_id` 로 고유 그룹을 줘 아무것도 cancel 하지 않게 한다.
+concurrency:
+  group: >-
+    claude-review-${{ github.event.issue.number || github.event.pull_request.number }}-${{
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'issue_comment' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+        (startsWith(github.event.comment.body, '@claude review') ||
+         startsWith(github.event.comment.body, '@claude re-review') ||
+         startsWith(github.event.comment.body, '@gemini review'))))
+      && 'review' || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # 실행 조건:
+    #  - pull_request: 같은 저장소(포크 아님) + draft 아님 → 최초/재오픈/ready 자동 리뷰
+    #  - issue_comment: PR 에 달린 코멘트 + 봇 아님 + 신뢰 작성자(OWNER/MEMBER/COLLABORATOR) + 본문에 트리거 문구
+    #    (`@claude review` / `@claude re-review` / `@gemini review`) 포함 → 재리뷰
+    #    신뢰 게이트: 저신뢰/외부 작성자가 재리뷰로 신뢰불가 PR head 를 시크릿 환경에 끌어오는 pwn-request 방지.
+    #    잔여 리스크: 신뢰 작성자가 '외부 포크 PR' 에 트리거를 남기면 그 fork head 는 여전히 시크릿 잡에서
+    #    체크아웃됨(pull_request 경로와 달리 여기엔 head.repo 포크 검사가 없음). private repo 라 현재 위험은 낮음.
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       !github.event.pull_request.draft)
+      ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.user.type != 'Bot' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+       (startsWith(github.event.comment.body, '@claude review') ||
+        startsWith(github.event.comment.body, '@claude re-review') ||
+        startsWith(github.event.comment.body, '@gemini review')))
+    runs-on: ubuntu-latest
+    # 최소 권한: diff 읽기(contents) + PR 대화/인라인 코멘트(pull-requests) +
+    # 👀 접수 리액션(issues — 리액션은 issues 엔드포인트라 issues: write 필요).
+    # github_token 을 명시하면 OIDC 교환을 건너뛰어 id-token: write 는 불필요.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      # 트리거 접수를 즉시 알리는 👀 리액션 (실제 리뷰는 이후 수십 초 소요).
+      # 멘션(issue_comment)이면 그 코멘트에, 자동(pull_request)이면 PR 본문에 단다.
+      # 리액션 실패가 리뷰를 막지 않도록 continue-on-error.
+      - name: Acknowledge with eyes reaction
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            gh api --method POST "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
+          else
+            gh api --method POST "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/reactions" -f content=eyes
+          fi
+
+      # issue_comment 이벤트는 기본 브랜치를 체크아웃하므로 PR head 를 명시적으로 지정한다.
+      # pull_request 이벤트는 ref 를 비우면 기본(merge ref) 체크아웃을 사용한다.
+      # fetch-depth: 0 → base..head diff 를 로컬 git 으로도 읽을 수 있게 전체 히스토리 확보.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # 신뢰불가 PR head 체크아웃 시 GITHUB_TOKEN 이 .git/config 에 남지 않게 한다.
+          persist-credentials: false
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          # Claude LLM API 인증 (GitHub 인증과 별개).
+          # secret 은 `claude setup-token` 으로 만든 OAuth 토큰(sk-ant-oat...) 이므로
+          # anthropic_api_key(x-api-key 헤더)가 아니라 claude_code_oauth_token(Bearer) 을 쓴다.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_REVIEW_API_KEY }}
+          # GitHub 코멘트용 토큰을 명시 → OIDC 교환 skip (GitHub App/ id-token 불필요).
+          # 실제 권한은 위 permissions 블록에서 부여된다.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # 인라인 코멘트에 자동으로 붙는 "Fix" 링크 제거.
+          include_fix_links: false
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            이 PR 을 시니어 코드 리뷰어 관점에서 리뷰하고, 결과를 한국어로 GitHub 에 게시해줘.
+            게시 형식은 "요약 코멘트 1개 + 라인별 인라인 코멘트" 다.
+
+            1) 전체 요약: `gh pr comment <PR번호> --body "본문"` 단일 명령으로 새 코멘트를 남긴다.
+               - 첫 줄 헤더 `## 코드 리뷰 (Claude)`
+               - 둘째 줄에 `리뷰 대상 커밋: <SHA>` 를 명시한다
+                 (SHA 는 `git log -1 --format=%h` 로 얻은 short SHA).
+               - 이 PR 이 무엇을 바꾸는지 2~4문장 요약
+               - 발견한 핵심 이슈를 심각도와 함께 불릿으로 정리
+
+            2) 구체적 지적: 문제마다 해당 파일의 정확한 라인에
+               `mcp__github_inline_comment__create_inline_comment` (`confirmed: true`) 로
+               인라인 코멘트를 단다. 심각도 높은 순으로 단다.
+               각 인라인 코멘트 형식:
+               - 첫 줄 심각도 배지: `🔴 High` / `🟡 Medium` / `🟢 Low`
+               - 왜 문제인지 설명
+               - 가능하면 GitHub committable suggestion 으로 수정안 제시:
+                 ```suggestion
+                 <해당 라인을 그대로 대체할 수정 코드>
+                 ```
+               - suggestion 은 diff 에서 추가/변경된(+ 쪽) 라인에만 달 수 있고,
+                 라인 번호는 변경 후 파일 기준이다. 라인 범위가 불확실하면
+                 suggestion 없이 설명만 단다.
+
+            리뷰 관점: 정확성/버그, 보안/민감정보, 성능, 레포 컨벤션(AGENTS.md, CLAUDE.md, .claude/docs/*).
+            정확한 라인 번호는 `gh pr diff` / `git diff` 로 확인한다.
+
+            중요:
+            - 어떤 파일도 수정하지 마 (리뷰 코멘트만 게시).
+            - 지적할 사항이 없으면 요약 코멘트에 "특이사항 없음" 만 남기고 인라인은 생략.
+            - 재리뷰 요청 시 이전 인라인 코멘트는 조회할 수 없어 중복될 수 있다.
+              가능하면 최근 변경분 위주로 지적해 중복을 줄인다.
+
+            실행 제약 (CI 샌드박스):
+            - 파이프(`|`), 리다이렉트(`>` `>>`), `&&` 로 이어붙인 복합 명령은 거부된다.
+              한 번에 명령 하나씩 단순하게 실행한다.
+            - 임시 파일에 쓰지 마 (Write/`> file` 불가). 요약 본문은 `--body` 인자로
+              직접 전달한다 (`--body-file` 사용 금지).
+            - diff 는 `gh pr diff` 단일 명령으로 읽는다.
+            - 리뷰 범위는 이 PR 의 diff + 저장소 로컬 파일로 한정. 외부 조회
+              (`gh api`, `gh release` 등)를 하지 말고, 검증이 필요한 권고는 권고로만 남긴다.
+            - 같은 명령이 거부되면 문법만 바꿔 재시도하지 말고, 허용된 단순 명령으로
+              우회하거나 생략한다.
+
+          # 읽기(Read/Grep/Glob/git) + 요약(gh pr comment) + 인라인 코멘트 MCP 툴 허용.
+          # Edit/Write 계열이 없어 파일 수정은 원천 차단된다. (v1 은 claude_args 로 지정)
+          claude_args: |
+            --max-turns 50
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git log:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -60,6 +60,22 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      # issue_comment 재리뷰 경로는 이벤트 페이로드에 PR head 저장소 정보가 없어
+      # if: 로 fork 여부를 거를 수 없다. secret 이 주입된 이 잡에서 체크아웃 전에
+      # PR head 가 base 와 같은 저장소(비-fork)인지 확인하고, fork 면 즉시 중단한다.
+      # (신뢰 작성자가 외부 포크 PR 에 트리거를 남겨 신뢰불가 head 를 특권 컨텍스트로
+      #  끌어오는 pwn-request 경로 차단. pull_request 경로는 위 if 에서 이미 fork 를 거른다.)
+      - name: Block re-review on fork PRs (untrusted head guard)
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cross=$(gh pr view "${{ github.event.issue.number }}" --repo "${{ github.repository }}" --json isCrossRepository --jq '.isCrossRepository')
+          if [ "$cross" != "false" ]; then
+            echo "::error::Re-review is not allowed on fork PRs (untrusted head checkout)."
+            exit 1
+          fi
+
       # 트리거 접수를 즉시 알리는 👀 리액션 (실제 리뷰는 이후 수십 초 소요).
       # 멘션(issue_comment)이면 그 코멘트에, 자동(pull_request)이면 PR 본문에 단다.
       # 리액션 실패가 리뷰를 막지 않도록 continue-on-error.

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -24,4 +24,4 @@ jobs:
           java-version: '21'
 
       - name: Generate & submit dependency graph (Gradle)
-        uses: gradle/actions/dependency-submission@v6
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:
@@ -27,8 +26,10 @@ jobs:
           echo "tag=$CLEAN_TAG" >> $GITHUB_OUTPUT
 
       - name: Print version
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          echo "Using release tag: ${{ steps.version.outputs.tag }}"
+          echo "Using release tag: $TAG"
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -37,7 +38,7 @@ jobs:
           distribution: "temurin"
 
       - name: Set application.yml values
-        uses: microsoft/variable-substitution@v1
+        uses: microsoft/variable-substitution@6287962da9e5b6e68778dc51e840caa03ca84495 # v1
         with:
           files: src/main/resources/application.yml
         env:
@@ -85,6 +86,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      id-token: write
     env:
       IMAGE: ${{ secrets.DOCKER_USERNAME }}/bigtablet-homepage-server
 
@@ -99,14 +103,14 @@ jobs:
           path: build/libs
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Docker login
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Build & Push image with SBOM & provenance
         id: docker_build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile
@@ -120,7 +124,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image (keyless)
         run: |
@@ -132,19 +136,19 @@ jobs:
     environment: production
     env:
       IMAGE: ${{ secrets.DOCKER_USERNAME }}/bigtablet-homepage-server
+      VERSION: ${{ needs.build.outputs.version }}
 
     steps:
       - name: Deploy to prod server
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
         with:
           host: ${{ secrets.HOST_PROD }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.PRIVATE_KEY }}
           port: ${{ secrets.PORT }}
-          envs: IMAGE
+          envs: IMAGE,VERSION
           script: |
             set -e
-            VERSION=${{ needs.build.outputs.version }}
             docker pull $IMAGE:$VERSION
             docker rm -f bigtablet-homepage-server 2>/dev/null || true
             docker run -d --name bigtablet-homepage-server --restart unless-stopped --network host \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} /app.jar
 ENV TZ=Asia/Seoul
 ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul -Dfile.encoding=UTF-8"
+USER 10001
 ENTRYPOINT ["java","-jar","/app.jar"]
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD curl -f http://127.0.0.1:8080/actuator/health || exit 1

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.bigtablet'
-version = '1.7.2'
+version = '1.7.3'
 description = 'bigtablet-homepage-server'
 
 java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
@@ -64,7 +64,7 @@ public class BlogApiHandler {
     @GetMapping("/search")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponseData<List<BlogResponse>> searchBlogByTitle(
-            @ModelAttribute
+            @ModelAttribute @Valid
             final PageRequest request,
             @RequestParam @NotBlank @Size(max = 255)
             final String title

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/dto/request/EditBlogRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/dto/request/EditBlogRequest.java
@@ -2,18 +2,24 @@ package com.bigtablet.bigtablethompageserver.domain.blog.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record EditBlogRequest(
         @NotNull
         Long idx,
         @NotBlank
+        @Size(max = 255)
         String titleKr,
         @NotBlank
+        @Size(max = 255)
         String titleEn,
         @NotBlank
+        @Size(max = 100000)
         String contentKr,
         @NotBlank
+        @Size(max = 100000)
         String contentEn,
         @NotBlank
+        @Size(max = 255)
         String imageUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/dto/request/RegisterBlogRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/dto/request/RegisterBlogRequest.java
@@ -1,16 +1,22 @@
 package com.bigtablet.bigtablethompageserver.domain.blog.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record RegisterBlogRequest(
         @NotBlank
+        @Size(max = 255)
         String titleKr,
         @NotBlank
+        @Size(max = 255)
         String titleEn,
         @NotBlank
+        @Size(max = 100000)
         String contentKr,
         @NotBlank
+        @Size(max = 100000)
         String contentEn,
         @NotBlank
+        @Size(max = 255)
         String imageUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/GetJobListRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/GetJobListRequest.java
@@ -4,6 +4,7 @@ import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Department;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Education;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
 import com.bigtablet.bigtablethompageserver.global.common.dto.request.PageRequest;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,6 +12,7 @@ import lombok.Setter;
 @Setter
 public class GetJobListRequest extends PageRequest {
 
+    @Size(max = 255)
     private String title;
     private Department department;
     private Education education;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
@@ -26,7 +26,7 @@ public class RecruitService {
      */
     @Transactional
     public Recruit save(RecruitInput input) {
-        log.info("[RecruitService] save - jobId={}, name={}", input.jobId(), input.name());
+        log.info("[RecruitService] save - jobId={}", input.jobId());
         RecruitEntity entity = recruitJpaRepository.save(RecruitEntity.create(input));
         return Recruit.of(entity);
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -41,7 +41,7 @@ public class RecruitUseCase {
      * @param request 채용 지원 등록 요청 정보
      */
     public void registerRecruit(RegisterRecruitRequest request) {
-        log.info("[RecruitUseCase] registerRecruit - jobId={}, name={}", request.jobId(), request.name());
+        log.info("[RecruitUseCase] registerRecruit - jobId={}", request.jobId());
         Job job = jobQueryService.find(request.jobId());
         jobQueryService.checkIsExpired(job);
         Recruit recruit = recruitService.save(request.toRecruitInput(job.idx()));

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
@@ -3,6 +3,7 @@ package com.bigtablet.bigtablethompageserver.domain.talent.application.service;
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.entity.TalentEntity;
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.repository.jpa.TalentJpaRepository;
 import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentNotFoundException;
+import com.bigtablet.bigtablethompageserver.global.common.util.LogMaskUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,7 +34,7 @@ public class TalentService {
             String portfolioUrl,
             List<String> etcUrl
     ) {
-        log.info("[TalentService] save - email={}, name={}", email, name);
+        log.info("[TalentService] save - email={}", LogMaskUtil.maskEmail(email));
         talentJpaRepository.save(TalentEntity.builder()
                 .email(email)
                 .name(name)

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
@@ -11,6 +11,7 @@ import com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request.Sen
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.model.Talent;
 import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentIsEmptyException;
 import com.bigtablet.bigtablethompageserver.global.common.util.CollectionValidator;
+import com.bigtablet.bigtablethompageserver.global.common.util.LogMaskUtil;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,7 @@ public class TalentUseCase {
      * @param request 인재풀 등록 요청 정보
      */
     public void registerTalent(RegisterTalentRequest request) {
-        log.info("[TalentUseCase] registerTalent - email={}, name={}", request.email(), request.name());
+        log.info("[TalentUseCase] registerTalent - email={}", LogMaskUtil.maskEmail(request.email()));
         talentQueryService.checkExistsByEmail(request.email());
         talentService.save(
                 request.email(),

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/RegisterTalentRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/RegisterTalentRequest.java
@@ -2,6 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
 import java.util.List;
@@ -9,13 +10,18 @@ import java.util.List;
 public record RegisterTalentRequest(
         @Email
         @NotBlank
+        @Size(max = 255)
         String email,
         @NotBlank
+        @Size(max = 255)
         String name,
         @NotBlank
+        @Size(max = 255)
         String department,
         @URL
         @NotBlank
+        @Size(max = 255)
         String portfolioUrl,
-        List<@URL String> etcUrl
+        @Size(max = 20)
+        List<@URL @Size(max = 255) String> etcUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/SendEmailToTalentRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/SendEmailToTalentRequest.java
@@ -1,10 +1,13 @@
 package com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record SendEmailToTalentRequest(
         @NotNull
         Long idx,
-        @NotNull
+        @NotBlank
+        @Size(max = 5000)
         String text
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/dto/request/PageRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/dto/request/PageRequest.java
@@ -14,7 +14,6 @@ public class PageRequest {
     @Positive
     private int page;
 
-    @NotNull
     @Positive
     @Max(1000)
     private int size;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/dto/request/PageRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/dto/request/PageRequest.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.global.common.dto.request;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
@@ -15,6 +16,7 @@ public class PageRequest {
 
     @NotNull
     @Positive
+    @Max(1000)
     private int size;
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/LogMaskUtil.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/LogMaskUtil.java
@@ -1,0 +1,24 @@
+package com.bigtablet.bigtablethompageserver.global.common.util;
+
+public final class LogMaskUtil {
+
+    private LogMaskUtil() {
+    }
+
+    /**
+     * 이메일 로컬파트를 마스킹하여 로그 PII 노출을 줄인다 (예: a***@bigtablet.com)
+     * @param email 원본 이메일
+     * @return 마스킹된 이메일
+     */
+    public static String maskEmail(String email) {
+        if (email == null) {
+            return "null";
+        }
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return "***";
+        }
+        return email.charAt(0) + "***" + email.substring(at);
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
@@ -13,8 +13,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    private static final Pattern CONTROL_CHARS = Pattern.compile("\\p{Cntrl}");
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -58,7 +61,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
         if (value == null) {
             return "-";
         }
-        return value.replaceAll("\\p{Cntrl}", "_");
+        return CONTROL_CHARS.matcher(value).replaceAll("_");
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
@@ -35,7 +35,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             int status = response.getStatus();
             org.slf4j.LoggerFactory.getLogger(RequestLoggingFilter.class).info(
                     "traceId={} ip={} method={} uri={} status={} ua={}",
-                    traceId, clientIp, method, decodedUri, status, ua
+                    traceId, sanitize(clientIp), method, sanitize(decodedUri), status, sanitize(ua)
             );
             MDC.remove("traceId");
         }
@@ -51,6 +51,14 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             return xri;
         }
         return req.getRemoteAddr();
+    }
+
+    // 로그 위조(CRLF 인젝션) 방지: 제어문자(개행 포함)를 '_'로 치환한다
+    private static String sanitize(String value) {
+        if (value == null) {
+            return "-";
+        }
+        return value.replaceAll("\\p{Cntrl}", "_");
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
@@ -49,11 +49,11 @@ public class SlackNotifier {
         section2.put("fields", List.of(
                 Map.of(
                         "type", "mrkdwn",
-                        "text", "*공고 제목:*\n" + jobTitle
+                        "text", "*공고 제목:*\n" + escapeMrkdwn(jobTitle)
                 ),
                 Map.of(
                         "type", "mrkdwn",
-                        "text", "*지원자 이름:*\n" + applicantName
+                        "text", "*지원자 이름:*\n" + escapeMrkdwn(applicantName)
                 ),
                 Map.of(
                         "type", "mrkdwn",
@@ -68,9 +68,17 @@ public class SlackNotifier {
         try {
             slackRestTemplate.postForEntity(webhookUrl, entity, String.class);
         } catch (RestClientException e) {
-            log.warn("[SlackNotifier] Slack 알림 발송 실패 - jobTitle={}, applicantName={}, recruitIdx={}, reason={}",
-                    jobTitle, applicantName, recruitIdx, e.getMessage());
+            log.warn("[SlackNotifier] Slack 알림 발송 실패 - jobTitle={}, recruitIdx={}, reason={}",
+                    jobTitle, recruitIdx, e.getMessage());
         }
+    }
+
+    // Slack mrkdwn 특수문자를 이스케이프해 사용자 입력으로 인한 링크/서식 인젝션을 방지한다
+    private static String escapeMrkdwn(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
 }

--- a/src/main/resources/templates/offer-email.html
+++ b/src/main/resources/templates/offer-email.html
@@ -62,8 +62,8 @@
 
                         <!-- 관리자 입력 본문 영역 -->
                         <div class="p-base"
-                             th:utext="${content}"
-                             style="font-family:Arial, sans-serif;color:#374151;font-size:16px;line-height:1.6;text-align:left;">
+                             th:text="${content}"
+                             style="font-family:Arial, sans-serif;color:#374151;font-size:16px;line-height:1.6;text-align:left;white-space:pre-line;">
                             <!-- 관리자 입력 본문이 들어갈 영역 -->
                         </div>
 


### PR DESCRIPTION
## 제목
Develop → main (v1.7.3) — 보안/CI 하드닝 릴리즈

## 작업한 내용
- **CI/CD 하드닝**: GitHub Actions 서드파티 액션을 커밋 SHA로 핀(`appleboy/ssh-action` 등), 릴리스 태그의 셸 인젝션 제거(env 경유), `id-token: write`를 서명 job으로 한정, CI 워크플로우 최소 권한(`contents: read`)
- **컨테이너/빌드**: Docker 비root 실행(`USER 10001`), Gradle 배포판 SHA-256 검증(`distributionSha256Sum`)
- **입력 검증**: `PageRequest` 상한(`@Max`), 요청 DTO `@Size`/`@NotBlank`, `/blog/search` `@Valid`
- **로그/인젝션**: 로그 PII 마스킹(`LogMaskUtil`), Slack mrkdwn 이스케이프, 요청 로그 제어문자 제거, offer 이메일 본문 HTML 이스케이프(`th:text`)
- **CI 자동화**: Claude PR 리뷰 워크플로우 추가(포크 head 체크아웃 가드 포함)

## 전달할 추가 이슈
- talent URL 컬럼(VARCHAR 255) 확장 + `@Size` 상향은 스키마 변경이라 후속 처리 예정.
