### PR TITLE
fix/scan-hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: "temurin"
 
       - name: Set application.yml values
-        uses: microsoft/variable-substitution@v1
+        uses: microsoft/variable-substitution@6287962da9e5b6e68778dc51e840caa03ca84495 # v1
         with:
           files: src/main/resources/application.yml
         env:

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -24,4 +24,4 @@ jobs:
           java-version: '21'
 
       - name: Generate & submit dependency graph (Gradle)
-        uses: gradle/actions/dependency-submission@v6
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:
@@ -27,8 +26,10 @@ jobs:
           echo "tag=$CLEAN_TAG" >> $GITHUB_OUTPUT
 
       - name: Print version
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          echo "Using release tag: ${{ steps.version.outputs.tag }}"
+          echo "Using release tag: $TAG"
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -37,7 +38,7 @@ jobs:
           distribution: "temurin"
 
       - name: Set application.yml values
-        uses: microsoft/variable-substitution@v1
+        uses: microsoft/variable-substitution@6287962da9e5b6e68778dc51e840caa03ca84495 # v1
         with:
           files: src/main/resources/application.yml
         env:
@@ -85,6 +86,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      id-token: write
     env:
       IMAGE: ${{ secrets.DOCKER_USERNAME }}/bigtablet-homepage-server
 
@@ -99,14 +103,14 @@ jobs:
           path: build/libs
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Docker login
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Build & Push image with SBOM & provenance
         id: docker_build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile
@@ -120,7 +124,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image (keyless)
         run: |
@@ -132,19 +136,19 @@ jobs:
     environment: production
     env:
       IMAGE: ${{ secrets.DOCKER_USERNAME }}/bigtablet-homepage-server
+      VERSION: ${{ needs.build.outputs.version }}
 
     steps:
       - name: Deploy to prod server
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f # v1.2.2
         with:
           host: ${{ secrets.HOST_PROD }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.PRIVATE_KEY }}
           port: ${{ secrets.PORT }}
-          envs: IMAGE
+          envs: IMAGE,VERSION
           script: |
             set -e
-            VERSION=${{ needs.build.outputs.version }}
             docker pull $IMAGE:$VERSION
             docker rm -f bigtablet-homepage-server 2>/dev/null || true
             docker run -d --name bigtablet-homepage-server --restart unless-stopped --network host \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} /app.jar
 ENV TZ=Asia/Seoul
 ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul -Dfile.encoding=UTF-8"
+USER 10001
 ENTRYPOINT ["java","-jar","/app.jar"]
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 CMD curl -f http://127.0.0.1:8080/actuator/health || exit 1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/api/BlogApiHandler.java
@@ -64,7 +64,7 @@ public class BlogApiHandler {
     @GetMapping("/search")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponseData<List<BlogResponse>> searchBlogByTitle(
-            @ModelAttribute
+            @ModelAttribute @Valid
             final PageRequest request,
             @RequestParam @NotBlank @Size(max = 255)
             final String title

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/dto/request/EditBlogRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/dto/request/EditBlogRequest.java
@@ -2,18 +2,24 @@ package com.bigtablet.bigtablethompageserver.domain.blog.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record EditBlogRequest(
         @NotNull
         Long idx,
         @NotBlank
+        @Size(max = 255)
         String titleKr,
         @NotBlank
+        @Size(max = 255)
         String titleEn,
         @NotBlank
+        @Size(max = 100000)
         String contentKr,
         @NotBlank
+        @Size(max = 100000)
         String contentEn,
         @NotBlank
+        @Size(max = 255)
         String imageUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/dto/request/RegisterBlogRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/blog/client/dto/request/RegisterBlogRequest.java
@@ -1,16 +1,22 @@
 package com.bigtablet.bigtablethompageserver.domain.blog.client.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record RegisterBlogRequest(
         @NotBlank
+        @Size(max = 255)
         String titleKr,
         @NotBlank
+        @Size(max = 255)
         String titleEn,
         @NotBlank
+        @Size(max = 100000)
         String contentKr,
         @NotBlank
+        @Size(max = 100000)
         String contentEn,
         @NotBlank
+        @Size(max = 255)
         String imageUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/GetJobListRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/job/client/dto/request/GetJobListRequest.java
@@ -4,6 +4,7 @@ import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Department;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.Education;
 import com.bigtablet.bigtablethompageserver.domain.job.domain.enums.RecruitType;
 import com.bigtablet.bigtablethompageserver.global.common.dto.request.PageRequest;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,6 +12,7 @@ import lombok.Setter;
 @Setter
 public class GetJobListRequest extends PageRequest {
 
+    @Size(max = 255)
     private String title;
     private Department department;
     private Education education;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/service/RecruitService.java
@@ -26,7 +26,7 @@ public class RecruitService {
      */
     @Transactional
     public Recruit save(RecruitInput input) {
-        log.info("[RecruitService] save - jobId={}, name={}", input.jobId(), input.name());
+        log.info("[RecruitService] save - jobId={}", input.jobId());
         RecruitEntity entity = recruitJpaRepository.save(RecruitEntity.create(input));
         return Recruit.of(entity);
     }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/recruit/application/usecase/RecruitUseCase.java
@@ -41,7 +41,7 @@ public class RecruitUseCase {
      * @param request 채용 지원 등록 요청 정보
      */
     public void registerRecruit(RegisterRecruitRequest request) {
-        log.info("[RecruitUseCase] registerRecruit - jobId={}, name={}", request.jobId(), request.name());
+        log.info("[RecruitUseCase] registerRecruit - jobId={}", request.jobId());
         Job job = jobQueryService.find(request.jobId());
         jobQueryService.checkIsExpired(job);
         Recruit recruit = recruitService.save(request.toRecruitInput(job.idx()));

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/service/TalentService.java
@@ -3,6 +3,7 @@ package com.bigtablet.bigtablethompageserver.domain.talent.application.service;
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.entity.TalentEntity;
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.repository.jpa.TalentJpaRepository;
 import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentNotFoundException;
+import com.bigtablet.bigtablethompageserver.global.common.util.LogMaskUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,7 +34,7 @@ public class TalentService {
             String portfolioUrl,
             List<String> etcUrl
     ) {
-        log.info("[TalentService] save - email={}, name={}", email, name);
+        log.info("[TalentService] save - email={}", LogMaskUtil.maskEmail(email));
         talentJpaRepository.save(TalentEntity.builder()
                 .email(email)
                 .name(name)

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/application/usecase/TalentUseCase.java
@@ -11,6 +11,7 @@ import com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request.Sen
 import com.bigtablet.bigtablethompageserver.domain.talent.domain.model.Talent;
 import com.bigtablet.bigtablethompageserver.domain.talent.exception.TalentIsEmptyException;
 import com.bigtablet.bigtablethompageserver.global.common.util.CollectionValidator;
+import com.bigtablet.bigtablethompageserver.global.common.util.LogMaskUtil;
 import com.bigtablet.bigtablethompageserver.global.infra.email.renderer.MailTemplateRenderer;
 import com.bigtablet.bigtablethompageserver.global.infra.email.service.EmailService;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,7 @@ public class TalentUseCase {
      * @param request 인재풀 등록 요청 정보
      */
     public void registerTalent(RegisterTalentRequest request) {
-        log.info("[TalentUseCase] registerTalent - email={}, name={}", request.email(), request.name());
+        log.info("[TalentUseCase] registerTalent - email={}", LogMaskUtil.maskEmail(request.email()));
         talentQueryService.checkExistsByEmail(request.email());
         talentService.save(
                 request.email(),

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/RegisterTalentRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/RegisterTalentRequest.java
@@ -2,6 +2,7 @@ package com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
 import java.util.List;
@@ -9,13 +10,18 @@ import java.util.List;
 public record RegisterTalentRequest(
         @Email
         @NotBlank
+        @Size(max = 255)
         String email,
         @NotBlank
+        @Size(max = 255)
         String name,
         @NotBlank
+        @Size(max = 255)
         String department,
         @URL
         @NotBlank
+        @Size(max = 255)
         String portfolioUrl,
-        List<@URL String> etcUrl
+        @Size(max = 20)
+        List<@URL @Size(max = 255) String> etcUrl
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/SendEmailToTalentRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/domain/talent/client/dto/request/SendEmailToTalentRequest.java
@@ -1,10 +1,13 @@
 package com.bigtablet.bigtablethompageserver.domain.talent.client.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record SendEmailToTalentRequest(
         @NotNull
         Long idx,
-        @NotNull
+        @NotBlank
+        @Size(max = 5000)
         String text
 ) {}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/dto/request/PageRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/dto/request/PageRequest.java
@@ -14,7 +14,6 @@ public class PageRequest {
     @Positive
     private int page;
 
-    @NotNull
     @Positive
     @Max(1000)
     private int size;

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/dto/request/PageRequest.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/dto/request/PageRequest.java
@@ -1,5 +1,6 @@
 package com.bigtablet.bigtablethompageserver.global.common.dto.request;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
@@ -15,6 +16,7 @@ public class PageRequest {
 
     @NotNull
     @Positive
+    @Max(1000)
     private int size;
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/LogMaskUtil.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/common/util/LogMaskUtil.java
@@ -1,0 +1,24 @@
+package com.bigtablet.bigtablethompageserver.global.common.util;
+
+public final class LogMaskUtil {
+
+    private LogMaskUtil() {
+    }
+
+    /**
+     * 이메일 로컬파트를 마스킹하여 로그 PII 노출을 줄인다 (예: a***@bigtablet.com)
+     * @param email 원본 이메일
+     * @return 마스킹된 이메일
+     */
+    public static String maskEmail(String email) {
+        if (email == null) {
+            return "null";
+        }
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return "***";
+        }
+        return email.charAt(0) + "***" + email.substring(at);
+    }
+
+}

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
@@ -13,8 +13,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    private static final Pattern CONTROL_CHARS = Pattern.compile("\\p{Cntrl}");
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -58,7 +61,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
         if (value == null) {
             return "-";
         }
-        return value.replaceAll("\\p{Cntrl}", "_");
+        return CONTROL_CHARS.matcher(value).replaceAll("_");
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/filter/RequestLoggingFilter.java
@@ -35,7 +35,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             int status = response.getStatus();
             org.slf4j.LoggerFactory.getLogger(RequestLoggingFilter.class).info(
                     "traceId={} ip={} method={} uri={} status={} ua={}",
-                    traceId, clientIp, method, decodedUri, status, ua
+                    traceId, sanitize(clientIp), method, sanitize(decodedUri), status, sanitize(ua)
             );
             MDC.remove("traceId");
         }
@@ -51,6 +51,14 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             return xri;
         }
         return req.getRemoteAddr();
+    }
+
+    // 로그 위조(CRLF 인젝션) 방지: 제어문자(개행 포함)를 '_'로 치환한다
+    private static String sanitize(String value) {
+        if (value == null) {
+            return "-";
+        }
+        return value.replaceAll("\\p{Cntrl}", "_");
     }
 
 }

--- a/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
+++ b/src/main/java/com/bigtablet/bigtablethompageserver/global/infra/slack/service/SlackNotifier.java
@@ -49,11 +49,11 @@ public class SlackNotifier {
         section2.put("fields", List.of(
                 Map.of(
                         "type", "mrkdwn",
-                        "text", "*공고 제목:*\n" + jobTitle
+                        "text", "*공고 제목:*\n" + escapeMrkdwn(jobTitle)
                 ),
                 Map.of(
                         "type", "mrkdwn",
-                        "text", "*지원자 이름:*\n" + applicantName
+                        "text", "*지원자 이름:*\n" + escapeMrkdwn(applicantName)
                 ),
                 Map.of(
                         "type", "mrkdwn",
@@ -68,9 +68,17 @@ public class SlackNotifier {
         try {
             slackRestTemplate.postForEntity(webhookUrl, entity, String.class);
         } catch (RestClientException e) {
-            log.warn("[SlackNotifier] Slack 알림 발송 실패 - jobTitle={}, applicantName={}, recruitIdx={}, reason={}",
-                    jobTitle, applicantName, recruitIdx, e.getMessage());
+            log.warn("[SlackNotifier] Slack 알림 발송 실패 - jobTitle={}, recruitIdx={}, reason={}",
+                    jobTitle, recruitIdx, e.getMessage());
         }
+    }
+
+    // Slack mrkdwn 특수문자를 이스케이프해 사용자 입력으로 인한 링크/서식 인젝션을 방지한다
+    private static String escapeMrkdwn(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
 }

--- a/src/main/resources/templates/offer-email.html
+++ b/src/main/resources/templates/offer-email.html
@@ -62,8 +62,8 @@
 
                         <!-- 관리자 입력 본문 영역 -->
                         <div class="p-base"
-                             th:utext="${content}"
-                             style="font-family:Arial, sans-serif;color:#374151;font-size:16px;line-height:1.6;text-align:left;">
+                             th:text="${content}"
+                             style="font-family:Arial, sans-serif;color:#374151;font-size:16px;line-height:1.6;text-align:left;white-space:pre-line;">
                             <!-- 관리자 입력 본문이 들어갈 영역 -->
                         </div>
 


### PR DESCRIPTION
전체 스캔(develop)에서 확인된 항목 중 **코드/설정으로 수정 가능한 건**을 적용했습니다. 각 수정은 빌드 통과 + 독립 적대적 검증(4그룹)을 거쳤습니다.

## 작업한 내용
### 워크플로우 / 컨테이너 / 빌드 (`config`)
- `appleboy/ssh-action@master` → 커밋 SHA 핀 (프로덕션 SSH 키가 주입되는 스텝, HIGH)
- 릴리스 태그가 `${{ }}`로 run/script에 직접 삽입되던 것 제거 → env(`TAG`/`VERSION`) 경유 (커맨드 인젝션 방지)
- `id-token: write`를 워크플로우 전역 → **docker(서명) job으로 한정** (최소 권한)
- 서드파티 액션 SHA 핀: `microsoft/variable-substitution`, `docker/setup-buildx-action`, `docker/build-push-action`, `sigstore/cosign-installer`, `gradle/actions/dependency-submission`
- `Dockerfile`: `USER 10001` (비root 실행)
- `gradle-wrapper.properties`: `distributionSha256Sum` 추가 (배포판 무결성 검증)

### 입력 검증 (`fix`)
- `PageRequest.size`에 `@Max(1000)` (비인증 목록 엔드포인트 자원 고갈 방지)
- `/blog/search`의 `PageRequest`에 `@Valid` 누락 보완
- talent/blog/job/email 요청 DTO에 `@Size` 상한(제목·URL·이름 255, 블로그 본문 100000[LONGTEXT], etcUrl 리스트 20), `SendEmailToTalentRequest.text` `@NotNull`→`@NotBlank`+`@Size`

### 로그/인젝션 (`fix`)
- 공용 `LogMaskUtil` 신설 → 공개 엔드포인트(talent/recruit) 로그의 이메일 마스킹·지원자 이름 제거 (PII)
- `SlackNotifier`: mrkdwn 특수문자 이스케이프 (미인증 지원자 이름 링크/서식 인젝션 방지)
- `RequestLoggingFilter`: 로그 기록 전 제어문자(CRLF) 제거 (로그 위조 방지)

## 검증
- `./gradlew build` 통과 (컴파일 + 테스트).
- 적대적 검증에서 잘못 핀된 액션 SHA 2건(annotated 태그의 태그객체 SHA 오사용)을 잡아 올바른 커밋 SHA로 정정함.

## 이번 PR에서 제외 (별도 처리 필요)
- **GCP 서비스계정 키의 아티팩트/이미지 내장** → 런타임 주입 전환 + 키 로테이션 (배포 파이프라인 변경 필요, Docker 레포 private이라 즉시 위험은 낮음)
- **JWT 24h TTL / 서버측 폐기 부재** → refresh 회전 등 구조 변경
- **초기 커밋의 하드코딩 비밀번호(git 이력)** → 이력 재작성(파괴적), 이미 defunct
- **`application-local.yml` 로컬 시크릿** → 자격증명 로테이션(코드 변경 아님)
- **deploy 태그 글롭 `'*'`** → 릴리스 패턴 제한(동작 변경 위험, environment 보호가 실제 게이트)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 게시글/채용/인재 관련 입력 검증이 강화되어 제목·내용·설명·이메일 등 길이/형식이 더 엄격히 제한됩니다.
  * 페이지 요청 size 상한(최대 1000)이 적용됩니다.
  * 요청/로그/Slack 알림에 제어문자 및 특수문자 이스케이프, 이메일 마스킹이 적용되어 출력 안정성과 개인정보 노출이 개선됩니다.
  * 관리자 오퍼 이메일 본문이 텍스트로 렌더링되어 HTML 해석 위험이 줄었습니다.
* **CI/CD**
  * 배포·CI에서 실행 설정과 작업 버전/권한이 더 안전하게 고정·정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->