### PR TITLE
ci: claude-review OTel 텔레메트리에 bt.worker=coderev 마커 추가

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -101,6 +101,11 @@ jobs:
           ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
       - uses: anthropics/claude-code-action@v1
+        # OTel resource 마커: 러너가 실행마다 새 user.id 를 만들어 인트라넷
+        # /admin/claude-usage 검역소에 휘발 설치로 쌓이는 것을 막는다.
+        # 인트라넷은 bt.worker 마커를 우선 판별해 CI 코드리뷰 워커로 분류한다 (intranet PR #2307).
+        env:
+          OTEL_RESOURCE_ATTRIBUTES: bt.worker=coderev
         with:
           # Claude LLM API 인증 (GitHub 인증과 별개).
           # secret 은 `claude setup-token` 으로 만든 OAuth 토큰(sk-ant-oat...) 이므로


### PR DESCRIPTION
## 배경
`claude-review.yml` 의 `anthropics/claude-code-action@v1` 실행이 인트라넷 `/api/otel` 로 텔레메트리를 보내는데, GitHub Actions 러너가 실행마다 새 OTel `user.id` 를 생성해 `/admin/claude-usage` 검역소에 휘발성 설치로 계속 쌓이고 있음.

인트라넷 PR moonjiho-bigtablet/intranet#2307 (feat/quarantine-worker-classification) 이 resource 속성 `bt.worker` 명시 마커를 최우선으로 판별하도록 구현됨 → 발신측(이 워크플로)에서 마커를 달아주면 검역소가 CI 코드리뷰 워커로 자동 분류한다.

## 변경
- `claude-code-action` 을 호출하는 스텝에 step-level `env` 추가:
  ```yaml
  env:
    OTEL_RESOURCE_ATTRIBUTES: bt.worker=coderev
  ```
- 워크플로 동작(트리거·권한·프롬프트)에는 변경 없음. 텔레메트리 resource 속성만 추가.

## Jira 티켓 없음 사유
제품 코드 변경이 아닌 CI 워크플로 정비(조직 공통 텔레메트리 마커 일괄 적용)로, DEV 티켓 없이 `ci/otel-worker-marker` 브랜치로 진행. 6개 레포 동일 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
