### PR TITLE
config: 로컬 개발용 docker compose (MySQL/Redis) 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bigtablet-homepage-server
 
+빅태블릿 홈페이지 백엔드 서버 (Spring Boot / MySQL / Redis).
+
 ## 빌드
 
 ```bash
@@ -17,3 +19,23 @@ bigtabletBuildCacheUrl=http://192.168.88.240:5071/cache/
 # (선택) 캐시 쓰기까지 켜려면 — 기본은 read-only
 # bigtabletBuildCachePush=true
 ```
+
+## 로컬 개발
+
+로컬 MySQL·Redis 는 docker compose 로 띄운다.
+
+```bash
+# 1. 의존 서비스 기동 (MySQL 8.0 + Redis 7)
+docker compose -f docker-compose.local.yml up -d
+
+# 2. 로컬 프로파일 설정 복사 (compose 기본값과 일치, 필요 시 수정)
+cp src/main/resources/application-local.yml.example src/main/resources/application-local.yml
+
+# 3. 서버 실행
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+- 접속 정보(로컬 전용): MySQL `localhost:3306`, DB `homepage`, 계정 `homepage`/`localdev` · Redis `localhost:6379`, 비밀번호 `localdev`
+- 이 레포는 Flyway 마이그레이션이 없으므로, local 프로파일은 `ddl-auto: update` 로 빈 DB 에 스키마를 생성한다 (운영은 `none`).
+- 완전한 기동에는 `.gitignore` 된 GCP credential JSON 이 `src/main/resources/` 에 추가로 필요하다 (팀 시크릿 저장소에서 수령). 자세한 내용은 `application-local.yml.example` 상단 주석 참고.
+- 초기화가 필요하면 `docker compose -f docker-compose.local.yml down -v` (볼륨까지 삭제).

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,46 @@
+# 로컬 개발 전용 MySQL / Redis 스택.
+# 사용법: docker compose -f docker-compose.local.yml up -d
+# 값들은 src/main/resources/application-local.yml.example 의 기본값과 일치한다.
+# 여기 비밀번호는 로컬 컨테이너 전용 더미 값이다 — 운영/개발 서버 접속 정보를 절대 넣지 말 것.
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: homepage-local-mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_DATABASE: homepage
+      MYSQL_USER: homepage
+      MYSQL_PASSWORD: localdev
+      MYSQL_ROOT_PASSWORD: localdev
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    volumes:
+      - homepage-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uhomepage", "-plocaldev"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s
+
+  redis:
+    image: redis:7-alpine
+    container_name: homepage-local-redis
+    # application.yml 이 spring.data.redis.password 를 요구하므로 requirepass 를 켠다.
+    command: ["redis-server", "--requirepass", "localdev"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - homepage-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "localdev", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  homepage-mysql-data:
+  homepage-redis-data:

--- a/src/main/resources/application-local.yml.example
+++ b/src/main/resources/application-local.yml.example
@@ -1,0 +1,40 @@
+# 로컬 개발용 프로파일 예시.
+#
+#   cp src/main/resources/application-local.yml.example src/main/resources/application-local.yml
+#
+# 후 docker-compose.local.yml 스택(MySQL/Redis)과 함께 사용한다.
+# application-local.yml 은 .gitignore 되어 있으며, 이 예시의 모든 값은 로컬 전용 더미다.
+# 실제 운영/개발 서버 접속 정보나 실키를 이 파일(예시 포함)에 절대 커밋하지 말 것.
+#
+# 주의: 완전한 기동에는 .gitignore 된 GCP credential 파일
+# (bigtablet-homepage-ffe77aff799f.json)이 src/main/resources/ 에 추가로 필요하다
+# (spring-cloud-gcp 가 기동 시 파일을 읽는다). 팀 시크릿 저장소(1Password)에서 받아서 넣는다.
+
+# application.yml 의 ${secrets.*} 플레이스홀더를 로컬 값으로 채운다.
+secrets:
+  # --- docker-compose.local.yml 과 일치 ---
+  DB_URL: jdbc:mysql://localhost:3306/homepage?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+  DB_USERNAME: homepage
+  DB_PASSWORD: localdev
+  REDIS_HOST: localhost
+  REDIS_PORT: 6379
+  REDIS_PASSWORD: localdev
+
+  # --- 이하 로컬 더미 (해당 기능을 실제로 쓰려면 팀 값으로 교체) ---
+  SMTP_PORT: 587
+  SMTP_EMAIL_NOREPLY: local-noreply@example.com
+  SMTP_PASSWORD_NOREPLY: local-dummy
+  SMTP_EMAIL_RECRUIT: local-recruit@example.com
+  SMTP_PASSWORD_RECRUIT: local-dummy
+  JWT_SECRET_KEY: local-dev-only-jwt-secret-key-0123456789abcdef0123456789abcdef
+  WEBAUTHN_RP_ID: localhost
+  WEBAUTHN_RP_NAME: Bigtablet Local
+  WEBAUTHN_ALLOWED_ORIGINS: http://localhost:3000
+  SLACK_WEBHOOK: http://localhost:9999/dummy-slack-webhook
+
+spring:
+  jpa:
+    hibernate:
+      # 이 레포는 Flyway 가 없고 운영은 ddl-auto: none 이다.
+      # 로컬 빈 DB 에 스키마를 만들기 위해 local 에서만 update 를 쓴다.
+      ddl-auto: update


### PR DESCRIPTION
## 배경

로컬 개발 시 MySQL·Redis 를 직접 설치·설정해야 해서 온보딩과 환경 재현이 번거로웠다. 로컬 전용 docker compose 스택과 local 프로파일 예시를 추가해 `up -d` 한 번으로 의존 서비스가 준비되도록 한다.

## 변경 사항

- `docker-compose.local.yml`: MySQL 8.0 + Redis 7 (utf8mb4, healthcheck, named volume). 비밀번호는 로컬 컨테이너 전용 더미(`localdev`)이며 실제 서버 접속 정보는 포함하지 않는다.
- `src/main/resources/application-local.yml.example`: compose 기본값과 일치하는 local 프로파일 예시 (base `application.yml` 의 `${secrets.*}` 플레이스홀더를 로컬 더미 값으로 채우는 방식)
- `README.md`: 로컬 개발 절차 문서화

## 사용법

```bash
docker compose -f docker-compose.local.yml up -d
cp src/main/resources/application-local.yml.example src/main/resources/application-local.yml
./gradlew bootRun --args='--spring.profiles.active=local'
```

## 참고

- 이 레포는 Flyway 가 없고 운영은 `ddl-auto: none` 이라, local 프로파일에서만 `ddl-auto: update` 로 빈 DB 에 스키마를 생성한다.
- 완전한 기동에는 .gitignore 된 GCP credential JSON(`bigtablet-homepage-ffe77aff799f.json`)이 별도로 필요하다(팀 시크릿 저장소 수령). 이 PR 범위 밖이며 example 상단 주석에 안내했다.
- DB 명(`homepage`)·계정은 커밋된 설정에 없어(시크릿 주입) 로컬 전용 관례값으로 정했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
