### PR TITLE
ci: dependabot PR 은 claude-review 스킵

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -42,7 +42,8 @@ jobs:
     if: >-
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
-       !github.event.pull_request.draft)
+       !github.event.pull_request.draft &&
+       github.event.pull_request.user.login != 'dependabot[bot]')
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&


### PR DESCRIPTION
## 배경 — claude-review 전면 실패 사건 (2026-08-12 조사 완료)

org 전반 claude-review 실패의 원인은 세 겹으로 확인됐다:

1. **org managed settings 의 `forceLoginOrgUUID`** (주범, 8/12 오후 배포) — 이 설정이 걸리면 CLI 가 시작 시 토큰의 org 소속을 profile 조회로 증명해야 하는데, CI 용 setup-token 은 scope 가 `user:inference` 뿐이라 증명 불가(profile 403, CI 내 실측). 에러 `This machine requires organization ae96b7e5-... but the token could not be validated`. 알려진 비호환([claude-code#56935](https://github.com/anthropics/claude-code/issues/56935)). → **코드가 아니라 관리자 콘솔에서 해당 키 제거로 해결(대표 진행 중)**. 토큰 자체는 유효함을 실측(messages 200).
2. **시크릿 토큰 이력** — 구 토큰은 8/12 06시(UTC)경 회수, 이날 오전 교체본은 401 무효였고, 최종적으로 유효 토큰이 재배포됨.
3. **dependabot PR 노이즈 (이 PR 가 고치는 것)** — dependabot 이 연 PR 에서 claude-code-action 이 `Workflow initiated by non-human actor` 로 하드 실패해 왔다 (7~8월 빨간불의 한 축). 의존성 범프 리뷰는 가치가 낮아, design-system/insight-app/intranet-app/notiiv-monorepo-web 과 동일하게 job 조건에서 dependabot 을 제외한다.

## 변경

job `if:` 의 pull_request 분기에 `github.event.pull_request.user.login != 'dependabot[bot]'` 한 줄 추가. (처음 올렸던 Haiku 모델 핀은 제거 — 이 시크릿 계정은 Sonnet 이 정상 동작함을 과거 성공 run 으로 확인, 불필요한 다운그레이드라 철회)

## 검증

관리자 콘솔에서 forceLoginOrgUUID 제거 후 이 PR 에 리뷰 run 이 초록불 + 리뷰 코멘트가 달리는지 확인 예정.

머지는 레포 담당자가 판단해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
