### PR TITLE
ci: develop push 시 dev 자동 배포(deploy-dev.yml)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,212 @@
+name: Deploy dev
+
+on:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+# develop 연속 push 시 두 배포가 같은 dev 호스트/컨테이너를 동시에 건드려 경합하는 것을 방지.
+# cancel-in-progress: false — 진행 중 배포(SSH deploy job)를 중단하지 않고 큐잉해 순차 실행한다.
+# (notiiv-server deploy-dev 와 동일 정책.)
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # 체크인된 gradle-wrapper.jar 이 변조되지 않았는지 검증 (빌드 부트스트랩 무결성).
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v5
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      # dev 는 prod(deploy.yml)와 달리 application.yml 시크릿 치환을 하지 않는다.
+      # ${secrets.*} 플레이스홀더는 dev 호스트의 env-file(SECRETS_* 환경변수)로 런타임 해석되므로
+      # 이미지에 앱 시크릿이 구워지지 않는다 (dev 값은 호스트 /home/dev-deploy/dev-env/*.env, 0600).
+      # 예외: GCS 서비스 키는 classpath 리소스로 읽으므로 prod 와 동일하게 빌드 시 주입한다.
+      - name: Create GCP Service Account Key File
+        shell: bash
+        env:
+          GCP_JSON: ${{ secrets.GCP_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p src/main/resources
+          printf '%s\n' "$GCP_JSON" > src/main/resources/bigtablet-homepage-ffe77aff799f.json
+
+      - name: chmod gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon --stacktrace bootJar 2>&1 | tee gradle.log
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-jar
+          path: build/libs/*.jar
+          retention-days: 1
+
+      - name: Upload Gradle log (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gradle-log
+          path: gradle.log
+          retention-days: 1
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      IMAGE: ${{ secrets.DOCKER_USERNAME }}/bigtablet-homepage-server-dev
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download JAR artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: app-jar
+          path: build/libs
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Docker login
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+      - name: Build & Push DEV image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.IMAGE }}:latest
+          provenance: true
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build, docker]
+    env:
+      IMAGE: ${{ secrets.DOCKER_USERNAME }}/bigtablet-homepage-server-dev
+
+    steps:
+      - name: Deploy to DEV (SSH)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.HOST_DEV }}
+          username: ${{ secrets.SSH_USER_DEV }}
+          key: ${{ secrets.PRIVATE_KEY_DEV }}
+          port: ${{ secrets.PORT_DEV }}
+          envs: IMAGE
+          script: |
+            set -e
+            docker pull $IMAGE:latest
+            docker rm -f bigtablet-homepage-server-dev 2>/dev/null || true
+            # bt-dev: dev 전용 mysql8/redis7 네트워크. env-file 은 호스트 0600(런타임 시크릿 주입).
+            # --no-healthcheck: Dockerfile HEALTHCHECK 가 /actuator/health 를 찌르지만
+            # actuator 의존성이 없어 상시 unhealthy 로 표기되는 것을 dev 에서는 끈다.
+            docker run -d --name bigtablet-homepage-server-dev --restart unless-stopped \
+              --network bt-dev \
+              --env-file /home/dev-deploy/dev-env/homepage-server.env \
+              --no-healthcheck \
+              -e JAVA_TOOL_OPTIONS="-Xms256m -Xmx768m -Duser.timezone=Asia/Seoul -Dfile.encoding=UTF-8" \
+              $IMAGE:latest
+            # Caddy(intranet_default)가 컨테이너명으로 프록시할 수 있게 두 네트워크에 조인.
+            docker network connect intranet_default bigtablet-homepage-server-dev 2>/dev/null || true
+            docker image prune -af || true
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [build, docker, deploy]
+    if: always()
+
+    steps:
+      - name: Slack notify (success)
+        if: needs.build.result == 'success' && needs.docker.result == 'success' && needs.deploy.result == 'success'
+        env:
+          GIT_SLACK_WEBHOOK_URL: ${{ secrets.GIT_SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n \
+              --arg repo "${{ github.repository }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg sha "${{ github.sha }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{
+                text: "✅ HOMEPAGE SERVER DEV 배포 성공",
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: "*✅ HOMEPAGE SERVER DEV 배포 성공*\n*Repo:* \($repo)\n*Branch:* \($branch)\n*SHA:* \($sha | .[0:7])\n*Actor:* \($actor)\n*Run:* <\($url)|Open Actions Run>"
+                    }
+                  }
+                ]
+              }')" \
+            "$GIT_SLACK_WEBHOOK_URL"
+
+      - name: Slack notify (failure)
+        if: needs.build.result == 'failure' || needs.docker.result == 'failure' || needs.deploy.result == 'failure'
+        env:
+          GIT_SLACK_WEBHOOK_URL: ${{ secrets.GIT_SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$(jq -n \
+              --arg repo "${{ github.repository }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg sha "${{ github.sha }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              --arg build_result "${{ needs.build.result }}" \
+              --arg docker_result "${{ needs.docker.result }}" \
+              --arg deploy_result "${{ needs.deploy.result }}" \
+              '{
+                text: "❌ HOMEPAGE SERVER DEV 배포 실패",
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: ("*❌ HOMEPAGE SERVER DEV 배포 실패*\n"
+                            + "*Repo:* \($repo)\n"
+                            + "*Branch:* \($branch)\n"
+                            + "*SHA:* \($sha[0:7])\n"
+                            + "*Actor:* \($actor)\n"
+                            + "*Run:* <\($url)|Open Actions Run>\n\n"
+                            + "*Step results*\n"
+                            + "• Build: `\($build_result)`\n"
+                            + "• Docker: `\($docker_result)`\n"
+                            + "• Deploy: `\($deploy_result)`")
+                    }
+                  }
+                ]
+              }')" \
+            "$GIT_SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## 개요
프론트 개발자가 백엔드를 로컬 구축하지 않고도 확인할 수 있도록, `develop` push 마다 dev 호스트로 자동 배포하는 워크플로를 추가합니다 (notiiv-server `deploy-dev.yml` 패턴 미러링, Slack 알림 포함).

## dev 호스트 / 접속
- **dev API URL**: `http://homepage-dev.34-47-78-111.sslip.io` (HTTP — sslip.io 는 LE 발급 쿼터 공유 문제로 dev 는 평문 서빙)
- 확인 방법(액추에이터 없음): `curl 'http://homepage-dev.34-47-78-111.sslip.io/job/list?page=1&size=5'` → **204/200** 이면 정상 기동
- 호스트: 기존 GCP VM(bigtablet-intranet 프로젝트, n2-standard-8) 재사용 — 신규 과금 리소스 없음. GCP VPC 방화벽이 22/80/443 만 허용하므로 앱 포트는 해당 VM 의 Caddy(80) Host 라우팅으로 노출
- **ephemeral IP 주의**: VM 외부 IP(34.47.78.111)가 바뀌면 `HOST_DEV` secret 과 sslip.io 호스트네임의 IP 부분을 갱신하면 됨 (비용 가드로 static IP 예약은 하지 않음)

## 구성
- dev 스택: 호스트에 mysql8(`bt-dev-mysql`) + redis7(`bt-dev-redis`) 상주 (`/home/dev-deploy/dev-env/docker-compose.yml`, 호스트 포트 미노출·`bt-dev` 네트워크 전용)
- **prod(deploy.yml)와 달리 앱 시크릿을 이미지에 굽지 않음**: `application.yml` 의 `${secrets.*}` 플레이스홀더를 호스트 0600 env-file(`/home/dev-deploy/dev-env/homepage-server.env`, `SECRETS_*` 환경변수)로 런타임 해석. JWT 키·DB 비밀번호는 dev 전용 신규 생성, SMTP·Slack 은 dev-noop 더미. 예외: **GCS 서비스 키만** classpath 리소스 특성상 prod 와 동일하게 빌드 시 주입(`GCP_SERVICE_KEY`)
- 스키마: prod 는 `ddl-auto: none` 이지만 dev 는 마이그레이션 도구가 없어 env 로 `SPRING_JPA_HIBERNATE_DDL_AUTO=update` 주입해 자동 생성
- WebAuthn rpId/origins 는 dev 호스트네임 + `http://localhost:3000` 으로 설정됨
- 참고: Dockerfile 의 HEALTHCHECK 가 `/actuator/health` 를 찌르지만 actuator 의존성이 없어 상시 unhealthy 로 표기됨 → dev 는 `--no-healthcheck` 로 기동 (Dockerfile 자체 수정은 별도 과제)

## 등록된 GitHub Secrets (이 PR 이 사용)
`HOST_DEV` / `SSH_USER_DEV` / `PORT_DEV` / `PRIVATE_KEY_DEV` (dev 전용 신규 ed25519, 호스트의 docker 그룹 전용 계정 `dev-deploy`) — 등록 완료. 기존 `DOCKER_USERNAME`/`DOCKER_PASSWORD`/`GCP_SERVICE_KEY`/`GIT_SLACK_WEBHOOK_URL` 재사용(이미지: `.../bigtablet-homepage-server-dev:latest`).

## 현재 상태
검증을 위해 동일 구성의 로컬 빌드 이미지(`:local`)가 이미 기동·헬스 확인됨(GCS 키는 더미 — 스토리지 업로드만 실패하며, 머지 후 첫 develop push 부터 실키로 동작). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)