### PR TITLE
chore: main 에 머지된 CI/캐시 개선 2건을 develop 으로 포팅 (#181, #182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           java-version: "21"
           distribution: "temurin"
+          cache: "gradle"
 
       - name: Set application.yml values
         uses: microsoft/variable-substitution@6287962da9e5b6e68778dc51e840caa03ca84495 # v1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           java-version: "21"
           distribution: "temurin"
+          cache: "gradle"
 
       # dev 는 prod(deploy.yml)와 달리 application.yml 시크릿 치환을 하지 않는다.
       # ${secrets.*} 플레이스홀더는 dev 호스트의 env-file(SECRETS_* 환경변수)로 런타임 해석되므로

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           java-version: "21"
           distribution: "temurin"
+          cache: "gradle"
 
       - name: Set application.yml values
         uses: microsoft/variable-substitution@6287962da9e5b6e68778dc51e840caa03ca84495 # v1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# bigtablet-homepage-server
+
+## 빌드
+
+```bash
+./gradlew build
+```
+
+로컬 빌드 캐시와 병렬 빌드는 `gradle.properties`에서 기본 활성화되어 있다.
+
+### 원격 빌드 캐시 (옵트인, 사내망 전용)
+
+사내망(LAN)에서 `~/.gradle/gradle.properties`에 아래 한 줄을 추가하면 r240 원격 빌드 캐시(팀원 간 컴파일 결과 공유)를 사용한다.
+
+```properties
+bigtabletBuildCacheUrl=http://192.168.88.240:5071/cache/
+# (선택) 캐시 쓰기까지 켜려면 — 기본은 read-only
+# bigtabletBuildCachePush=true
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bigtablet-homepage-server
 
+빅태블릿 홈페이지 백엔드 서버 (Spring Boot / MySQL / Redis).
+
 ## 빌드
 
 ```bash
@@ -17,3 +19,23 @@ bigtabletBuildCacheUrl=http://192.168.88.240:5071/cache/
 # (선택) 캐시 쓰기까지 켜려면 — 기본은 read-only
 # bigtabletBuildCachePush=true
 ```
+
+## 로컬 개발
+
+로컬 MySQL·Redis 는 docker compose 로 띄운다.
+
+```bash
+# 1. 의존 서비스 기동 (MySQL 8.0 + Redis 7)
+docker compose -f docker-compose.local.yml up -d
+
+# 2. 로컬 프로파일 설정 복사 (compose 기본값과 일치, 필요 시 수정)
+cp src/main/resources/application-local.yml.example src/main/resources/application-local.yml
+
+# 3. 서버 실행
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+- 접속 정보(로컬 전용): MySQL `localhost:3306`, DB `homepage`, 계정 `homepage`/`localdev` · Redis `localhost:6379`, 비밀번호 `localdev`
+- 이 레포는 Flyway 마이그레이션이 없으므로, local 프로파일은 `ddl-auto: update` 로 빈 DB 에 스키마를 생성한다 (운영은 `none`).
+- 완전한 기동에는 `.gitignore` 된 GCP credential JSON 이 `src/main/resources/` 에 추가로 필요하다 (팀 시크릿 저장소에서 수령). 자세한 내용은 `application-local.yml.example` 상단 주석 참고.
+- 초기화가 필요하면 `docker compose -f docker-compose.local.yml down -v` (볼륨까지 삭제).

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,46 @@
+# 로컬 개발 전용 MySQL / Redis 스택.
+# 사용법: docker compose -f docker-compose.local.yml up -d
+# 값들은 src/main/resources/application-local.yml.example 의 기본값과 일치한다.
+# 여기 비밀번호는 로컬 컨테이너 전용 더미 값이다 — 운영/개발 서버 접속 정보를 절대 넣지 말 것.
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: homepage-local-mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_DATABASE: homepage
+      MYSQL_USER: homepage
+      MYSQL_PASSWORD: localdev
+      MYSQL_ROOT_PASSWORD: localdev
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    volumes:
+      - homepage-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uhomepage", "-plocaldev"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s
+
+  redis:
+    image: redis:7-alpine
+    container_name: homepage-local-redis
+    # application.yml 이 spring.data.redis.password 를 요구하므로 requirepass 를 켠다.
+    command: ["redis-server", "--requirepass", "localdev"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - homepage-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "localdev", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  homepage-mysql-data:
+  homepage-redis-data:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -16,7 +16,7 @@ services:
       MYSQL_ROOT_PASSWORD: localdev
       TZ: Asia/Seoul
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     volumes:
       - homepage-mysql-data:/var/lib/mysql
     healthcheck:
@@ -32,7 +32,7 @@ services:
     # application.yml 이 spring.data.redis.password 를 요구하므로 requirepass 를 켠다.
     command: ["redis-server", "--requirepass", "localdev"]
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - homepage-redis-data:/data
     healthcheck:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+# Gradle 빌드 성능 설정
+# 로컬 빌드 캐시 활성화 — 변경 없는 태스크의 출력을 재사용한다.
+org.gradle.caching=true
+# 독립적인 태스크를 병렬로 실행한다.
+org.gradle.parallel=true
+# Gradle 데몬 힙 상한 (GitHub Actions 러너 7GB 메모리에서도 안전한 값)
+org.gradle.jvmargs=-Xmx2g

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,22 @@
 rootProject.name = 'bigtablet-homepage-server'
+
+// ── 사내 원격 빌드 캐시 (옵트인, 사내망 전용) ────────────────────────────────
+// 사내망(LAN)에서 ~/.gradle/gradle.properties 에 아래 한 줄을 추가하면
+// r240 원격 빌드 캐시를 사용한다. 미설정 시 이 블록은 아무 동작도 하지 않는다.
+//
+//   bigtabletBuildCacheUrl=http://192.168.88.240:5071/cache/
+//
+def bigtabletBuildCacheUrl = providers.gradleProperty('bigtabletBuildCacheUrl').getOrNull()
+if (bigtabletBuildCacheUrl != null) {
+    // 쓰기(push)는 기본 꺼짐 — 공유 캐시 오염을 막기 위해 신뢰 머신(CI 등)만
+    // bigtabletBuildCachePush=true 로 명시 옵트인한다. 개발자 기본은 read-only.
+    def bigtabletBuildCachePush = providers.gradleProperty('bigtabletBuildCachePush').getOrNull() == 'true'
+    buildCache {
+        remote(HttpBuildCache) {
+            url = uri(bigtabletBuildCacheUrl)
+            // 사내망(LAN) 전용 캐시 노드 — 외부 비노출 전제로 HTTP 허용. TLS 도입 시 재검토.
+            allowInsecureProtocol = true
+            push = bigtabletBuildCachePush
+        }
+    }
+}

--- a/src/main/resources/application-local.yml.example
+++ b/src/main/resources/application-local.yml.example
@@ -1,0 +1,40 @@
+# 로컬 개발용 프로파일 예시.
+#
+#   cp src/main/resources/application-local.yml.example src/main/resources/application-local.yml
+#
+# 후 docker-compose.local.yml 스택(MySQL/Redis)과 함께 사용한다.
+# application-local.yml 은 .gitignore 되어 있으며, 이 예시의 모든 값은 로컬 전용 더미다.
+# 실제 운영/개발 서버 접속 정보나 실키를 이 파일(예시 포함)에 절대 커밋하지 말 것.
+#
+# 주의: 완전한 기동에는 .gitignore 된 GCP credential 파일
+# (bigtablet-homepage-ffe77aff799f.json)이 src/main/resources/ 에 추가로 필요하다
+# (spring-cloud-gcp 가 기동 시 파일을 읽는다). 팀 시크릿 저장소(1Password)에서 받아서 넣는다.
+
+# application.yml 의 ${secrets.*} 플레이스홀더를 로컬 값으로 채운다.
+secrets:
+  # --- docker-compose.local.yml 과 일치 ---
+  DB_URL: jdbc:mysql://localhost:3306/homepage?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+  DB_USERNAME: homepage
+  DB_PASSWORD: localdev
+  REDIS_HOST: localhost
+  REDIS_PORT: 6379
+  REDIS_PASSWORD: localdev
+
+  # --- 이하 로컬 더미 (해당 기능을 실제로 쓰려면 팀 값으로 교체) ---
+  SMTP_PORT: 587
+  SMTP_EMAIL_NOREPLY: local-noreply@example.com
+  SMTP_PASSWORD_NOREPLY: local-dummy
+  SMTP_EMAIL_RECRUIT: local-recruit@example.com
+  SMTP_PASSWORD_RECRUIT: local-dummy
+  JWT_SECRET_KEY: local-dev-only-jwt-secret-key-0123456789abcdef0123456789abcdef
+  WEBAUTHN_RP_ID: localhost
+  WEBAUTHN_RP_NAME: Bigtablet Local
+  WEBAUTHN_ALLOWED_ORIGINS: http://localhost:3000
+  SLACK_WEBHOOK: http://localhost:9999/dummy-slack-webhook
+
+spring:
+  jpa:
+    hibernate:
+      # 이 레포는 Flyway 가 없고 운영은 ddl-auto: none 이다.
+      # 로컬 빈 DB 에 스키마를 만들기 위해 local 에서만 update 를 쓴다.
+      ddl-auto: update


### PR DESCRIPTION
## 배경

오늘 올린 CI/캐시 개선 PR 2건(#181, #182)을 **base 를 잘못 잡아 `main` 으로 머지**했습니다. 이 레포의 실제 컨벤션은 `feature → develop` 이고, `main` 은 `develop → main` 릴리스 PR 로만 도달합니다. (@qtaghdi 지적, 머지 이력으로도 확인)

그 결과 **develop 에서 작업하는 구성원들은 개선 효과를 전혀 못 받고**, 다음 릴리스 PR 에서 충돌이 납니다. 이 PR 은 `main` 에 이미 들어간 변경을 `develop` 으로 포팅해 정합을 맞추는 정정 작업입니다.

> 이미 `main` 에 머지된 내용이라 **기능적으로 새로운 변경은 없습니다.** 아래 "추가 변경" 1건만 예외입니다.

## 포함 커밋

| 원본 PR | main squash SHA | 내용 |
|---|---|---|
| #181 | `3691bc9` | Gradle 빌드 캐시 도입 (로컬 + CI + 옵트인 원격) |
| #182 | `bfdbe67` | 로컬 개발용 docker compose (MySQL/Redis) + local 프로파일 예시 |

## 충돌 해소 내역

**#182 는 클린 적용.** #181 에서 아래 2가지를 처리했습니다.

**1. `gradlew.bat` 164줄 변경 제외 (의도적)**

원본 #181 커밋에는 `gradlew.bat` 이 164줄 변경된 것으로 들어가 있는데, 이건 코드 변경이 아니라 `.gitattributes` 의 `*.bat text eol=crlf` 재정규화로 생긴 **순수 개행(CRLF) churn** 입니다. `--ignore-cr-at-eol` 로 비교하면 **내용 차이가 0** 입니다.

포팅에 섞으면 리뷰 노이즈만 되고 develop 쪽에도 같은 churn 을 퍼뜨리게 되어 **제외**했습니다. 그래서 이 PR 의 diff 에는 `gradlew.bat` 이 없습니다.

> 참고로 이 재정규화 때문에 체크아웃 직후 `gradlew.bat` 이 항상 "modified" 로 뜨고 `git rebase` 가 unstaged changes 로 실패합니다. 별개 이슈로 정리할 가치가 있어 보입니다.

**2. README 순차 병합**

develop 에는 `README.md` 자체가 없었습니다(#181 이 main 에서 신규 생성). #181 → #182 순서로 적용해 **양쪽 섹션이 모두 살아 있습니다** — `## 빌드` / `### 원격 빌드 캐시`(#181), `## 로컬 개발`(#182).

**스킵한 커밋 없음** — develop 에 선반영된 건은 없었습니다.

## 추가 변경 1건

`deploy-dev.yml` 의 `setup-java` 에도 `cache: "gradle"` 추가

#181 은 main 기준이라 `ci.yml` / `deploy.yml` 에만 캐시를 넣었습니다. 그런데 **`deploy-dev.yml` 은 develop 에만 있는 워크플로**(#184, main 에는 아직 없음)라 포팅 대상에서 원천적으로 빠집니다. develop 에서 가장 자주 도는 워크플로가 정작 캐시를 못 받는 셈이라 같은 의도를 일관되게 적용했습니다.

별도 커밋으로 분리했으니 범위 밖이라 판단하시면 해당 커밋만 드롭하셔도 됩니다.

## 요청

**리뷰 후 머지** 부탁드립니다. 제가 임의로 머지하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - Docker Compose 기반의 로컬 MySQL·Redis 개발 환경을 제공합니다.
  - 로컬 실행에 필요한 애플리케이션 설정 예시와 초기화 안내를 추가했습니다.
  - 선택적으로 원격 빌드 캐시를 사용할 수 있습니다.

- **문서**
  - 프로젝트 개요, 빌드 방법, 로컬 개발 절차, 접속 정보와 초기화 안내를 README에 추가했습니다.

- **개선**
  - Gradle 의존성 및 빌드 캐시, 병렬 실행을 활성화해 빌드와 배포 효율성을 높였습니다.
  - 데몬 메모리 설정을 조정해 빌드 성능을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->