### PR TITLE
ci: claude-review 모델을 Haiku 로 고정 (base=develop 재제출)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -161,6 +161,9 @@ jobs:
 
           # 읽기(Read/Grep/Glob/git) + 요약(gh pr comment) + 인라인 코멘트 MCP 툴 허용.
           # Edit/Write 계열이 없어 파일 수정은 원천 차단된다. (v1 은 claude_args 로 지정)
+          # 구독 시트 OAuth 토큰은 Opus/Sonnet 요청이 플랜 게이트에 즉시 거부된다
+          # (1턴 · cost $0 · is_error:true). 이 토큰으로 성립하는 모델은 Haiku 뿐이라 명시 고정.
           claude_args: |
+            --model claude-haiku-4-5-20251001
             --max-turns 50
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git log:*)"


### PR DESCRIPTION
## 왜 develop 이어야 실효가 있나

`pull_request` 트리거 워크플로는 **PR 의 base 브랜치에 있는 워크플로 파일**이 실행된다.
이 레포의 컨벤션은 feature→develop 이라 직원 PR 은 대부분 base=develop 이고,
`.github/workflows/claude-review.yml` 수정이 `main` 에만 들어가면 실제 직원 PR 리뷰에는 **전혀 반영되지 않는다.**

원래 올라와 있던 #183 은 base=main 으로 열려 있어 실효가 없어서 close 하고, 같은 취지의 최소 변경을
develop 파일 실물에 적용해 이 PR 로 다시 올린다. (main 버전을 통째로 복사하지 않고, develop 파일에
`--model` 라인만 추가)

## 무엇을 고치나

claude-review 워크플로가 쓰는 구독 시트 OAuth 토큰(`CLAUDE_CODE_REVIEW_API_KEY`, `sk-ant-oat…`)은
**플랜 게이트** 때문에 Opus/Sonnet 요청이 즉시 거부된다. 한도 초과가 아니라 플랜 게이트라 리셋 헤더도 없고
재시도해도 통과하지 못한다. 이 토큰으로 성립하는 계층은 Haiku 뿐이므로
`--model claude-haiku-4-5-20251001` 로 명시 고정한다.

## 실측 근거

- 실패 시그니처가 플랜 게이트 거부와 정확히 일치: `"num_turns": 1`, `"total_cost_usd": 0`, `"is_error": true`
  → `##[error]Claude execution failed: result is_error:true`
  (예: https://github.com/Bigtablet/bigtablet-homepage-server/actions/runs/31590039387)
- `gh run list --workflow claude-review.yml --event pull_request` 기준 **조회 창(최근 15회) 전량 실패**

머지는 하지 않습니다 — 대표 검토용으로 열어둡니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)